### PR TITLE
Thermostat Functionality, Generic Dim/Brighten, and Tag Validation (#19)

### DIFF
--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -510,8 +510,10 @@ function syncAndDiscoverDevices(token, success, failure) {
 
 		// Now retrieve all other items
 		(function () {
+			itemLoop:
 			for (var itemNum in items) {
 				var item = items[itemNum];
+				tagLoop:
 				for (var tagNum in item.tags) {
 					var tag = item.tags[tagNum];
 
@@ -578,7 +580,7 @@ function syncAndDiscoverDevices(token, success, failure) {
 						}
 						break;
 					default:
-						break;
+						break tagLoop;
 					}
 					if (traits !== null) {
 						console.log('openhabGoogleAssistant - syncAndDiscoverDevices - SYNC is adding: ' + item.name + ' with tag: ' + tag);

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -206,7 +206,8 @@ function getTempData(item) {
 function getLightData(item) {
   console.log(item.name + " State: " + item.state);
   return {
- 		online: true,
+	on: item.state === 'ON' ? true : (item.state > 0 ? true : false),
+	online: true,
     	brightness: Number(item.state)
 	};
 }
@@ -214,7 +215,7 @@ function getLightData(item) {
 function getSwitchData(item) {
   console.log(item.name + " State: " + item.state);
   return {
- 		on: item.state === 'ON' ? true : false,
+ 		on: item.state === 'ON' ? true : (item.state > 0 ? true : false),
  		online: true
 	};
 }

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -127,6 +127,8 @@ function getItemsState(request,response) {
 			case 'Group' :
 				var checkTags = res.tags.toString(); //future proof in case Groups are used for other invocations
 				if (checkTags.includes("Thermostat")) data = getTempData(res);
+			case 'Dimmer':
+				data = getLightData(res);
 			default:
 				var checkTags = res.tags.toString();
 				if (checkTags.includes("CurrentTemperature")) data = getTempData(res);
@@ -199,6 +201,13 @@ function getTempData(item) {
 	return thermData;
 }
 
+function getLightData(item) {
+  console.log(item.name + " State: " + item.state);
+  return {
+ 		online: true,
+    	brightness: Number(item.state)
+	};
+}
 
 function getSwitchData(item) {
   console.log(item.name + " State: " + item.state);

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -127,8 +127,10 @@ function getItemsState(request,response) {
 			case 'Group' :
 				var checkTags = res.tags.toString(); //future proof in case Groups are used for other invocations
 				if (checkTags.includes("Thermostat")) data = getTempData(res);
+				break;
 			case 'Dimmer':
 				data = getLightData(res);
+				break;
 			default:
 				var checkTags = res.tags.toString();
 				if (checkTags.includes("CurrentTemperature")) data = getTempData(res);

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -520,12 +520,6 @@ function syncAndDiscoverDevices(token, success, failure) {
 					// An array of traits that this device supports.
 					var traits = null;
 					
-					//needs to be maintained to ensure no erroneous tags crash the sync
-					var validTags = ['Lighting', 'Switchable', 'CurrentTemperature', 'Thermostat'];
-					if (validTags.includes(tag.toString()) === false) {
-						console.log('openhabGoogleAssistant - syncAndDiscoverDevices - SYNC is not adding: ' + item.name + ' with tag: ' + tag +'. Reason: Tag not supported');
-						break;
-					}  
 
 					// A special object defined by the partner (openHAB) which will be attached to future QUERY and EXECUTE requests.
 					// Partners (openHAB) can use this object to store additional information about the device to improve performance or routing

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -166,25 +166,24 @@ function getItemsState(request,response) {
  */
 function getTempData(item) {
 			
-  			//If request has a Thermostat group in the tags, then it should sent only the members, otherwise send it to getThermostatItems Function
-         	var thermItems = item.tags.indexOf('Thermostat') > -1 ? getThermostatItems(item.members) : getThermostatItems([item]);		
-			console.log(thermItems);
-  			//Are we dealing with Fahrenheit?
-          	var isF = item.tags.indexOf('Fahrenheit') >= 0 ? true : false;
-         	
-         	//store long json variables in easier variables to work with below
-			var tstatMode = thermItems.hasOwnProperty('heatingCoolingMode') ? (thermItems.heatingCoolingMode.state.length == 1 ? utils.normalizeThermostatMode(thermItems.heatingCoolingMode.state) : items.heatingCoolingMode.state) : ''
-            var currTemp =  thermItems.hasOwnProperty('currentTemperature') ? (isF ? utils.toC(thermItems.currentTemperature.state) : thermItems.currentTemperature.state) : '';
-         	var tarTemp = thermItems.hasOwnProperty('targetTemperature') ? (isF ? utils.toC(thermItems.targetTemperature.state) : thermItems.targetTemperature.state) : '';
-         	var curHum = thermItems.hasOwnProperty('currentHumidity') ? thermItems.currentHumidity.state : '';
+	//If request has a Thermostat group in the tags, then it should sent only the members, otherwise send it to getThermostatItems Function
+	var thermItems = item.tags.indexOf('Thermostat') > -1 ? getThermostatItems(item.members) : getThermostatItems([item]);		
 
-            //populate only the necessary json values
-         	if (thermItems.hasOwnProperty('heatingCoolingMode')) item.thermostatMode = tstatMode;
-         	if (thermItems.hasOwnProperty('currentTemperature')) item.thermostatTemperatureAmbient = Number(parseFloat(currTemp).toFixed(1));
-         	if (thermItems.hasOwnProperty('targetTemperature')) item.thermostatTemperatureSetpoint = Number(parseFloat(tarTemp).toFixed(1));
-            if (thermItems.hasOwnProperty('currentHumidity')) item.thermostatHumidityAmbient = Number(parseFloat(curHum).toFixed(0));
-            
-            return item;
+	//Are we dealing with Fahrenheit?
+	var isF = item.tags.indexOf('Fahrenheit') >= 0 ? true : false;
+	//store long json variables in easier variables to work with below
+	var tstatMode = thermItems.hasOwnProperty('heatingCoolingMode') ? (thermItems.heatingCoolingMode.state.length == 1 ? utils.normalizeThermostatMode(thermItems.heatingCoolingMode.state) : thermItems.heatingCoolingMode.state) : ''
+	var currTemp =  thermItems.hasOwnProperty('currentTemperature') ? (isF ? utils.toC(thermItems.currentTemperature.state) : thermItems.currentTemperature.state) : '';
+	var tarTemp = thermItems.hasOwnProperty('targetTemperature') ? (isF ? utils.toC(thermItems.targetTemperature.state) : thermItems.targetTemperature.state) : '';
+	var curHum = thermItems.hasOwnProperty('currentHumidity') ? thermItems.currentHumidity.state : '';
+	
+	//populate only the necessary json values
+	if (thermItems.hasOwnProperty('heatingCoolingMode')) item.thermostatMode = tstatMode;
+	if (thermItems.hasOwnProperty('currentTemperature')) item.thermostatTemperatureAmbient = Number(parseFloat(currTemp).toFixed(1));
+	if (thermItems.hasOwnProperty('targetTemperature')) item.thermostatTemperatureSetpoint = Number(parseFloat(tarTemp).toFixed(1));
+	if (thermItems.hasOwnProperty('currentHumidity')) item.thermostatHumidityAmbient = Number(parseFloat(curHum).toFixed(0));
+	
+	return item;
 }
 
 

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -115,35 +115,36 @@ function getItemsState(request,response) {
 	// Get status for all devices, and return array of promises... one for each device.
 	let promises = devices.map(function(device) {	
 		return getItemAsync(authToken, device.id).then(function(res){ // success
-			console.log('openhabGoogleAssistant - getItemsState - result for ' + device.id + ': ' + JSON.stringify(res))
-          	var thermoTag = res.tags.indexOf('Thermostat') > -1; //Is this device a Thermostat?
-          	var	tempTag = res.tags.indexOf('CurrentTemperature') > -1; //or is it just temperature?
-       if (thermoTag || tempTag) {
-			
-         	var items = thermoTag ? getThermostatItems(res.members) : getThermostatItems([res]);		
+		console.log('openhabGoogleAssistant - getItemsState - result for ' + device.id + ': ' + JSON.stringify(res))
+          	
+		//check tags from rest command
+		var thermoTag = res.tags.indexOf('Thermostat') > -1; //Is this device a Thermostat?
+          	var tempTag = res.tags.indexOf('CurrentTemperature') > -1; //or is it just temperature?
 		
-         	var tempUnit = res.tags.indexOf('Fahrenheit'); //Is it C or F?
-          	var isF = tempUnit ? tempUnit > -1 : 'false';
+		if (thermoTag || tempTag) {
+			var items = thermoTag ? getThermostatItems(res.members) : getThermostatItems([res]);		
+	         	var tempUnit = res.tags.indexOf('Fahrenheit'); //Is it C or F?
+        	  	var isF = tempUnit ? tempUnit > -1 : 'false';
          	
-         	//store long json variables in easier variables to work with
+			//store long json variables in easier variables to work with
 			var tstatMode = items.hasOwnProperty('heatingCoolingMode') ? (items.heatingCoolingMode.state.length == 1 ? utils.normalizeThermostatMode(items.heatingCoolingMode.state) : items.heatingCoolingMode.state) : ''
-            var currTemp =  items.hasOwnProperty('currentTemperature') ? (isF ? utils.toC(items.currentTemperature.state) : items.currentTemperature.state) : '';
-         	var tarTemp = items.hasOwnProperty('targetTemperature') ? (isF ? utils.toC(items.targetTemperature.state) : items.targetTemperature.state) : '';
-         	var curHum = items.hasOwnProperty('currentHumidity') ? items.currentHumidity.state : '';
+			var currTemp =  items.hasOwnProperty('currentTemperature') ? (isF ? utils.toC(items.currentTemperature.state) : items.currentTemperature.state) : '';
+			var tarTemp = items.hasOwnProperty('targetTemperature') ? (isF ? utils.toC(items.targetTemperature.state) : items.targetTemperature.state) : '';
+			var curHum = items.hasOwnProperty('currentHumidity') ? items.currentHumidity.state : '';
 
-            var values = {}
+			var values = {}
 
-            //populate json values
-            values.id = device.id;
-            values.data = {};
-            values.data.online = true;
-         	if (items.hasOwnProperty('heatingCoolingMode')) values.data.thermostatMode = tstatMode;
-         	if (items.hasOwnProperty('currentTemperature')) values.data.thermostatTemperatureAmbient = Number(parseFloat(currTemp).toFixed(1));
-         	if (items.hasOwnProperty('targetTemperature')) values.data.thermostatTemperatureSetpoint = Number(parseFloat(tarTemp).toFixed(1));
-            if (items.hasOwnProperty('currentHumidity')) values.data.thermostatHumidityAmbient = Number(parseFloat(curHum).toFixed(0));
-            
-            return values;
-        }
+			//populate json values
+			values.id = device.id;
+			values.data = {};
+			values.data.online = true;
+			if (items.hasOwnProperty('heatingCoolingMode')) values.data.thermostatMode = tstatMode;
+			if (items.hasOwnProperty('currentTemperature')) values.data.thermostatTemperatureAmbient = Number(parseFloat(currTemp).toFixed(1));
+			if (items.hasOwnProperty('targetTemperature')) values.data.thermostatTemperatureSetpoint = Number(parseFloat(tarTemp).toFixed(1));
+			if (items.hasOwnProperty('currentHumidity')) values.data.thermostatHumidityAmbient = Number(parseFloat(curHum).toFixed(0));
+		
+			return values;
+		}
    		else {
 			return {
 				id: device.id,

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -515,7 +515,13 @@ function syncAndDiscoverDevices(token, success, failure) {
 
 					// An array of traits that this device supports.
 					var traits = null;
-
+					
+					//needs to be maintained to ensure no erroneous tags crash the sync
+					var validTags = ['Lighting', 'Switchable', 'CurrentTemperature', 'Thermostat'];
+					if (validTags.includes(tag.toString()) === false) {
+						console.log('openhabGoogleAssistant - syncAndDiscoverDevices - SYNC is not adding: ' + item.name + ' with tag: ' + tag +'. Reason: Tag not supported');
+						break;
+					}  
 
 					// A special object defined by the partner (openHAB) which will be attached to future QUERY and EXECUTE requests.
 					// Partners (openHAB) can use this object to store additional information about the device to improve performance or routing

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -119,18 +119,16 @@ function getItemsState(request,response) {
           	console.log('openhabGoogleAssistant - getItemsState - result for ' + device.id + ': '  + JSON.stringify(res));
           	
           	var data = {};
-          
-          	switch (res.type) {
-              case 'Switch' :
-                data = getSwitchData(res);
-                break;
-              case 'Group' :
-                var checkTags = res.tags.toString();
-				if (checkTags.includes("Thermostat") || checkTags.includes("CurrentTemperature")) data = getTempData(res);
-              default:
-                break;
-            }
-
+          switch (res.type) {
+		case 'Switch' :
+			data = getSwitchData(res);
+			break;
+		case 'Group' :
+			var checkTags = res.tags.toString();
+			if (checkTags.includes("Thermostat") || checkTags.includes("CurrentTemperature")) data = getTempData(res);
+		default :
+			break;
+	  }
 			return {
 				id: device.id,
 					data: data

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -517,8 +517,8 @@ function syncAndDiscoverDevices(token, success, failure) {
 							traits = [
 								'action.devices.traits.TemperatureSetting'
 								];
-                          	deviceTypes = 'action.devices.types.THERMOSTAT';
 							setTempFormat(item,attributeDetails);
+                          				deviceTypes = 'action.devices.types.THERMOSTAT';
 						}
 						break;
 					case 'Thermostat':

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openHAB.google-assistant-smarthome",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A Google Assistant, Actions on Google based implementation for openHAB",
   "repository": {
     "type": "git",

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -55,22 +55,25 @@ function normalizeThermostatMode(mode){
 	var m = mode;
 	switch (mode) {
 	case '0': //off, not supported! Weird. But nothing else todo.
-		m = 'OFF';
+		m = 'off';
 		break;
 	case '1': //heating
-		m = 'HEAT';
+		m = 'heat';
 		break;
 	case '2': //cooling
-		m = 'COOL';
+		m = 'cool';
 		break;
 	case 'heat-cool': //nest auto
+		m = 'heatcool'
+		break;
 	case '3': //auto
-		m = 'AUTO';
+		m = 'heatcool';
 		break;
 	}
 	return m.toUpperCase();
 }
 
+//Should this be removed? JSON format appears to be Alexa Skill format, not Google Assistant
 function isEventFahrenheit(event){
 	return event.payload.appliance.additionalApplianceDetails.temperatureFormat &&
 	event.payload.appliance.additionalApplianceDetails.temperatureFormat === 'fahrenheit';

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -49,7 +49,7 @@ function generateControlError(messageId, name, code, description) {
 	return result;
 }
 
-//Normilizes numeric/string thermostat modes to Alexa friendly ones
+//Normilizes numeric/string thermostat modes to Google Assistant friendly ones
 function normalizeThermostatMode(mode){
 	//if state returns as a decimal type, convert to string, this is a very common thermo pattern
 	var m = mode;
@@ -67,10 +67,13 @@ function normalizeThermostatMode(mode){
 		m = 'heatcool'
 		break;
 	case '3': //auto
-		m = 'heatcool';
+		m = 'on';
 		break;
+    default:
+        m = 'off';
+        break;
 	}
-	return m.toUpperCase();
+	return m.toLowerCase();
 }
 
 //Should this be removed? JSON format appears to be Alexa Skill format, not Google Assistant


### PR DESCRIPTION
Formal Pull Request:

Fixes* Thermostat functionality: Other modes need to be tested (currently only heat works), Celsius needs to be confirmed, and grouped commands (multiple thermostats) just state numbers with "What's the inside temperature"?

Various other cosmetic changes (e.g. deviceTypes format is string (no brackets) per Google Action API directions and validation.