### PR TITLE
query pays respect to traits

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -36,8 +36,10 @@ exports.openhabGoogleAssistant = function(request, response) {
 			openhab.handleSync(request, response);
 			return;
 		case "action.devices.QUERY":
+			openhab.handleQuery(request, response);
+			return;
 		case "action.devices.EXECUTE":
-			openhab.handleQueryAndExecute(request, response);
+			openhab.handleExecute(request, response);
 			return;
 		}
 	}

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -71,13 +71,28 @@ exports.handleQuery = function (request, response) {
 	let promises = devices.map(function(device) {	
 		return getItemAsync(authToken, device.id).then(function(res){ // success
 			console.log('result for ' + device.id + ': ' + JSON.stringify(res))
-			return {
+			let retValue = {
 				id: device.id,
 				data: {
-					on: res.state === 'ON' ? true : false,
 					online: true
 				}
 			};
+
+			let traits = getSwitchableTraits(res);
+			for (let i = 0; i < traits.length; i++) {
+				switch (traits[i]) {
+					case 'action.devices.traits.OnOff':
+						retValue.data.on = res.state === 'ON' ? true : false;
+						break; 
+					case 'action.devices.traits.Brightness':
+						retValue.data.brightness = parseInt(res.state) || 0;
+						break; 
+					case 'action.devices.traits.ColorSpectrum':
+						// retValue.data.color = { "name": "cerulean", "spectrumRGB": 31655 };
+						break; 
+				}
+			}
+			return retValue;
 		},function(res){ // failure
 			return {
 				id: device.id,

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -92,6 +92,9 @@ exports.handleQuery = function (request, response) {
 				case 'Dimmer':
 					itemData = getLightData(res);
 					break;
+				case 'Color':
+					itemData = getColorData(res);
+					break;
 				default:
 					var checkTags = res.tags.toString();
 					if (checkTags.includes("CurrentTemperature")) itemData = getTempData(res);
@@ -113,9 +116,9 @@ exports.handleQuery = function (request, response) {
 						break;
 					case 'action.devices.traits.TemperatureSetting':
 						retValue.data.thermostatMode = itemdata.thermostatMode
-						retValue.data.thermostatTemperatureAmbient = itemdata.thermostatTemperatureAmbient 
-						retValue.data.thermostatTemperatureSetpoint  = itemdata.thermostatTemperatureSetpoint
-						retValue.data.thermostatHumidityAmbient  = itemdata.thermostatHumidityAmbient
+						retValue.data.thermostatTemperatureAmbient = itemdata.thermostatTemperatureAmbient
+						retValue.data.thermostatTemperatureSetpoint = itemdata.thermostatTemperatureSetpoint
+						retValue.data.thermostatHumidityAmbient = itemdata.thermostatHumidityAmbient
 						break;
 				}
 			}
@@ -209,7 +212,7 @@ function getTempData(item) {
 
 function getLightData(item) {
 	return {
-		on: item.state === 'ON' ? true : (Number(item.state) > 0 ? true : false),
+		on: item.state === 'ON' ? true : (item.state === 0 ? false : true),
 		brightness: Number(item.state)
 	};
 }
@@ -217,6 +220,22 @@ function getLightData(item) {
 function getSwitchData(item) {
 	return {
 		on: item.state === 'ON' ? true : false,
+	};
+}
+
+function getColorData(item) {
+	var hsvArray = item.state.split(",").map(function (val) {
+		return Number(val);
+	});
+	var color = colr.fromHsvArray(hsvArray);
+	var rgbColor = parseInt(color.toHex().replace('#', ''), 16);
+
+	return {
+		color: {
+			"spectrumRGB": rgbColor
+		},
+		"brightness": hsvArray[2],
+		"on": hsvArray[2] === 0 ? false : true,
 	};
 }
 

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -82,7 +82,7 @@ exports.handleQuery = function (request, response) {
 			for (let i = 0; i < traits.length; i++) {
 				switch (traits[i]) {
 					case 'action.devices.traits.OnOff':
-						retValue.data.on = res.state === 'ON' ? true : false;
+						retValue.data.on = res.state === 'ON' ? true : (res.state > 0 ? true : false);
 						break; 
 					case 'action.devices.traits.Brightness':
 						retValue.data.brightness = parseInt(res.state) || 0;

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -46,52 +46,7 @@ exports.handleSync = function (request, response) {
 	});	
 }
 
-exports.handleQueryAndExecute = function (request, response) {
-	let requestIntent = request.body.inputs[0].intent;
-	switch (requestIntent) {
-		case 'action.devices.QUERY':
-			getItemsState(request,response);
-			
-			break;
-		case 'action.devices.EXECUTE':
-
-			let requestCommands = request.body.inputs[0].payload.commands;
-
-			for (let i = 0; i < requestCommands.length; i++) {
-				let currentCommand = requestCommands[i];
-				for (let j = 0; j < currentCommand.execution.length; j++) {
-					let currentExecutionCommand = currentCommand.execution[j];
-		
-					switch (currentExecutionCommand.command) {
-					case 'action.devices.commands.OnOff':
-						turnOnOff(request, response);
-						break;
-					case 'action.devices.commands.BrightnessAbsolute':
-						adjustBrightness(request, response);
-						break;
-					case 'action.devices.commands.ChangeColor':
-					case 'action.devices.commands.ColorAbsolute':
-						adjustColor(request, response);
-						break;
-					case 'action.devices.commands.ThermostatTemperatureSetpoint':
-						adjustTemperature(request, response);
-						break;
-					}
-				}
-			}	
-
-			break;
-		default:
-			// TODO: handle error.
-			break;
-	}
-
-}
-
-/**
- * Returns state for devices in the request 
- */
-function getItemsState(request,response) {
+exports.handleQuery = function (request, response) {
 	let authToken = request.headers.authorization ? request.headers.authorization.split(' ')[1] : null;
 	let devices = request.body.inputs[0].payload.devices;
 
@@ -149,6 +104,33 @@ function getItemsState(request,response) {
 				'Access-Control-Allow-Headers': 'Content-Type, Authorization'
 			}).json({error: "failed"});			
 		})
+}
+
+exports.handleExecute = function (request, response) {
+	let requestCommands = request.body.inputs[0].payload.commands;
+
+	for (let i = 0; i < requestCommands.length; i++) {
+		let currentCommand = requestCommands[i];
+		for (let j = 0; j < currentCommand.execution.length; j++) {
+			let currentExecutionCommand = currentCommand.execution[j];
+
+			switch (currentExecutionCommand.command) {
+			case 'action.devices.commands.OnOff':
+				turnOnOff(request, response);
+				break;
+			case 'action.devices.commands.BrightnessAbsolute':
+				adjustBrightness(request, response);
+				break;
+			case 'action.devices.commands.ChangeColor':
+			case 'action.devices.commands.ColorAbsolute':
+				adjustColor(request, response);
+				break;
+			case 'action.devices.commands.ThermostatTemperatureSetpoint':
+				adjustTemperature(request, response);
+				break;
+			}
+		}
+	}	
 }
 
 /**


### PR DESCRIPTION
Possible solution for #23 

QUERY returns now a value for each trait, or at least for "onoff" and "brightness". 
For "onoff", it might be necessary to return for category "DimmableLight" an "ON" if the value is '!== "0"' instead of '== "ON"'. But I am not sure if this should be based on category or on type.

Also the intent is now only handled in index.js, not in openhab.js anymore to simplify the code a little.

This change has not been tested! Its more a suggestion how it could work a little better. That's why the two commits are not sqashed.