### PR TITLE
Additional Functionality & General Updates (Thermostat, Query Behavior)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -36,8 +36,10 @@ exports.openhabGoogleAssistant = function(request, response) {
 			openhab.handleSync(request, response);
 			return;
 		case "action.devices.QUERY":
+			openhab.handleQuery(request, response);
+			return;
 		case "action.devices.EXECUTE":
-			openhab.handleQueryAndExecute(request, response);
+			openhab.handleExecute(request, response);
 			return;
 		}
 	}

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -217,7 +217,7 @@ function getTempData(item) {
  **/
 function getLightData(item) {
 	return {
-		on: item.state === 'ON' ? true : (item.state === 0 ? false : true),
+		on: item.state === 'ON' ? true : (Number(item.state) === 0 ? false : true),
 		brightness: Number(item.state)
 	};
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openHAB.google-assistant-smarthome",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A Google Assistant, Actions on Google based implementation for openHAB",
   "repository": {
     "type": "git",

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -49,28 +49,34 @@ function generateControlError(messageId, name, code, description) {
 	return result;
 }
 
-//Normilizes numeric/string thermostat modes to Alexa friendly ones
+//Normilizes numeric/string thermostat modes to Google Assistant friendly ones
 function normalizeThermostatMode(mode){
 	//if state returns as a decimal type, convert to string, this is a very common thermo pattern
 	var m = mode;
 	switch (mode) {
 	case '0': //off, not supported! Weird. But nothing else todo.
-		m = 'OFF';
+		m = 'off';
 		break;
 	case '1': //heating
-		m = 'HEAT';
+		m = 'heat';
 		break;
 	case '2': //cooling
-		m = 'COOL';
+		m = 'cool';
 		break;
 	case 'heat-cool': //nest auto
-	case '3': //auto
-		m = 'AUTO';
+		m = 'heatcool'
 		break;
+	case '3': //auto
+		m = 'on';
+		break;
+    default:
+        m = 'off';
+        break;
 	}
-	return m.toUpperCase();
+	return m.toLowerCase();
 }
 
+//Should this be removed? JSON format appears to be Alexa Skill format, not Google Assistant
 function isEventFahrenheit(event){
 	return event.payload.appliance.additionalApplianceDetails.temperatureFormat &&
 	event.payload.appliance.additionalApplianceDetails.temperatureFormat === 'fahrenheit';


### PR DESCRIPTION
@mdopp If you agree now you can also withdraw your PR as we had discussed.

@marziman :

I have now squashed the commits from mine and @mdopp - unfortunately, I was unable to merge #22 as I don't fully understand the changes.

The tag issue seemed to be a simple fix and I saw some people were having this issue because of misspelling and such.  Let me know if you have any questions, here is the synopsis below:

I am currently running on this code with no errors and have tried upwards, downwards, backwards, and forwards to try to "trick" my commands using Google Cloud Console and REST commands.  So far so good.

Highlights:
- Adds Thermostat functionality (tested with heating, and manually adjusted to emulate)
- Ignores misspelled or unsupported tags (should not crash on sync)
- You can dim generically without specifying by how much: e.g. "Dim [x] lights" instead of "Dim [x] lights 50%".  Google controls the interval on all generic commands.

Changelog:
- UPDATE -> Split Query and Execute to separate functions
- UPDATE -> Query Function retrieves item data, then process response by trait (per @mdopp)
- UPDATE -> Execute function goes also by trait (per @mdopp)
- NEW -> getLightData: retrieves lighting attributes OH item (on/off for switch lights and also brightness 0-100 for dimmers)
- NEW -> getSwitchData: retrieves switch attriutes from OH item (on/off)
- NEW -> getColorData: retrieves color attributes from OH item, SpectrumRGB
- NEW -> getTempData: Google requires to first query thermostat before executing.  Therefore this code will provide appropriate response based on query.
- UPDATE -> getThermostatItems: fixed to allow for CurrentTemperature tag (standalone sensor/item without Thermostat group)
- UPDATE -> adjustTemperatureWithItems: Fixed isF (function from utils is from Alexa code)
- UPDATE -> syncAndDiscoverDevices: Named loop to allow switch default to break out to avoid crashing on sync on mismatch item tags
- UPDATE -> syncAndDiscoverDevices: Google wants deviceType as string, removed brackets as it was a soft-warning from their reference docs
- UPDATE -> getSwitchableTraits: Allow for Temperature and Thermostat to handle Query-Trait functionality (per @mdopp)