### PR TITLE
Added support for blinds

### DIFF
--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -99,9 +99,9 @@ exports.handleQuery = function (request, response) {
 				case 'Color':
 					itemData = getColorData(res);
 					break;
-        case 'Rollershutter':
-          itemData = getRollerShutterData(res);
-          break;
+        			case 'Rollershutter':
+          				itemData = getRollerShutterData(res);
+          				break;
 				default:
 					if (checkTags.includes("CurrentTemperature")) itemData = getTempData(res);
 					break;
@@ -128,10 +128,9 @@ exports.handleQuery = function (request, response) {
 						retValue.data.thermostatTemperatureSetpoint = itemData.thermostatTemperatureSetpoint
 						retValue.data.thermostatHumidityAmbient = itemData.thermostatHumidityAmbient
 						break;
-          case 'action.devices.traits.OpenClose':
-            retValue.data.openPercent = itemData.openPercent;
-            retValue.data.on = itemData.on;
-            break;
+          				case 'action.devices.traits.OpenClose':
+            					retValue.data.openPercent = itemData.openPercent;
+            					break;
 				}
 			}
 			return retValue;
@@ -191,12 +190,12 @@ exports.handleExecute = function (request, response) {
 				case 'action.devices.commands.ThermostatSetMode':
 					adjustThermostatMode(request, response, i, j);
 					break;
-        case 'action.devices.commands.OpenClose':
-          changeOpenClose(request, response, i, j);
-          break;
-        case 'action.devices.commands.StartStop':
-          changeStartStop(request, response, i, j);
-          break;
+        			case 'action.devices.commands.OpenClose':
+          				changeOpenClose(request, response, i, j);
+          				break;
+        			case 'action.devices.commands.StartStop':
+          				changeStartStop(request, response, i, j);
+          				break;
 			}
 		}
 	}
@@ -834,7 +833,7 @@ function syncAndDiscoverDevices(token, success, failure) {
 									'action.devices.traits.TemperatureSetting'
 								];
 								setTempFormat(item, attributeDetails);
-                deviceTypes = 'action.devices.types.THERMOSTAT';
+                						deviceTypes = 'action.devices.types.THERMOSTAT';
 							}
 							break;
 						case 'Thermostat':
@@ -847,14 +846,14 @@ function syncAndDiscoverDevices(token, success, failure) {
 								deviceTypes = 'action.devices.types.THERMOSTAT';
 							}
 							break;
-            case 'Blinds':
-              deviceTypes = 'action.devices.types.BLINDS';
-              traits = [
-                'action.devices.traits.OpenClose',
-                'action.devices.traits.StartStop' //only for stop command
+            					case 'Blinds':
+              						deviceTypes = 'action.devices.types.BLINDS';
+              						traits = [
+                						'action.devices.traits.OpenClose',
+                						'action.devices.traits.StartStop' //only for stop command
   							];
-              attributeDetails.openDirection = ['UP', 'DOWN']
-  						break;
+              						attributeDetails.openDirection = ['UP', 'DOWN']
+  							break;
 						default:
 							break;
 					}

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -100,8 +100,8 @@ exports.handleQuery = function (request, response) {
 					itemData = getColorData(res);
 					break;
 				case 'Rollershutter':
-          			itemData = getRollerShutterData(res);
-          			break;
+					itemData = getRollerShutterData(res);
+					break;
 				default:
 					if (checkTags.includes("CurrentTemperature")) itemData = getTempData(res);
 					break;
@@ -849,8 +849,8 @@ function syncAndDiscoverDevices(token, success, failure) {
 						case 'Blinds':
 							deviceTypes = 'action.devices.types.BLINDS';
 							traits = [
-									'action.devices.traits.OpenClose',
-									'action.devices.traits.StartStop' //only for stop command
+								'action.devices.traits.OpenClose',
+								'action.devices.traits.StartStop' //only for stop command
   							];
 							attributeDetails.openDirection = ['UP', 'DOWN'];
   							break;

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -99,9 +99,9 @@ exports.handleQuery = function (request, response) {
 				case 'Color':
 					itemData = getColorData(res);
 					break;
-        			case 'Rollershutter':
-          				itemData = getRollerShutterData(res);
-          				break;
+				case 'Rollershutter':
+          			itemData = getRollerShutterData(res);
+          			break;
 				default:
 					if (checkTags.includes("CurrentTemperature")) itemData = getTempData(res);
 					break;
@@ -123,14 +123,14 @@ exports.handleQuery = function (request, response) {
 						retValue.data.color = itemData.color;
 						break;
 					case 'action.devices.traits.TemperatureSetting':
-						retValue.data.thermostatMode = itemData.thermostatMode
-						retValue.data.thermostatTemperatureAmbient = itemData.thermostatTemperatureAmbient
-						retValue.data.thermostatTemperatureSetpoint = itemData.thermostatTemperatureSetpoint
-						retValue.data.thermostatHumidityAmbient = itemData.thermostatHumidityAmbient
+						retValue.data.thermostatMode = itemData.thermostatMode;
+						retValue.data.thermostatTemperatureAmbient = itemData.thermostatTemperatureAmbient;
+						retValue.data.thermostatTemperatureSetpoint = itemData.thermostatTemperatureSetpoint;
+						retValue.data.thermostatHumidityAmbient = itemData.thermostatHumidityAmbient;
 						break;
-          				case 'action.devices.traits.OpenClose':
-            					retValue.data.openPercent = itemData.openPercent;
-            					break;
+					case 'action.devices.traits.OpenClose':
+						retValue.data.openPercent = itemData.openPercent;
+            			break;
 				}
 			}
 			return retValue;
@@ -183,19 +183,19 @@ exports.handleExecute = function (request, response) {
 					break;
 				case 'action.devices.commands.ActivateScene':
 					adjustScene(request, response, i, j);
-					break
+					break;
 				case 'action.devices.commands.ThermostatTemperatureSetpoint':
 					adjustThermostatTemperature(request, response, i, j);
 					break;
 				case 'action.devices.commands.ThermostatSetMode':
 					adjustThermostatMode(request, response, i, j);
 					break;
-        			case 'action.devices.commands.OpenClose':
-          				changeOpenClose(request, response, i, j);
-          				break;
-        			case 'action.devices.commands.StartStop':
-          				changeStartStop(request, response, i, j);
-          				break;
+				case 'action.devices.commands.OpenClose':
+					changeOpenClose(request, response, i, j);
+					break;
+				case 'action.devices.commands.StartStop':
+					changeStartStop(request, response, i, j);
+					break;
 			}
 		}
 	}
@@ -846,13 +846,13 @@ function syncAndDiscoverDevices(token, success, failure) {
 								deviceTypes = 'action.devices.types.THERMOSTAT';
 							}
 							break;
-            					case 'Blinds':
-              						deviceTypes = 'action.devices.types.BLINDS';
-              						traits = [
-                						'action.devices.traits.OpenClose',
-                						'action.devices.traits.StartStop' //only for stop command
+						case 'Blinds':
+							deviceTypes = 'action.devices.types.BLINDS';
+							traits = [
+									'action.devices.traits.OpenClose',
+									'action.devices.traits.StartStop' //only for stop command
   							];
-              						attributeDetails.openDirection = ['UP', 'DOWN']
+							attributeDetails.openDirection = ['UP', 'DOWN'];
   							break;
 						default:
 							break;


### PR DESCRIPTION
Added support for blinds (Rollershutter in openhab)

``` xml
Rollershutter Roll_OG_Media "Rollladen" <rollershutter> ["Blinds"] {channel="zwave:device:xxxxxx:xxxxxx:blinds_control"}`
```

The German commands are:

Ok, Google [Rollladen , Jalousie, Name] … 

… [öffnen, schließen, hoch, runter]
… [0 .. 100] % [öffnen, schließen, hoch, runter] 
… ¼, ½, ¾ [öffnen, schließen, hoch, runter]
… zur Hälfte [öffnen, schließen, hoch, runter]

Ok, Google stopp [Rollladen , Jalousie, Name]

Question:
Ok, Google ist [der Rollladen, die Jalousie, Name] [offen, geschlossen]?

Answer:
Das Gerät [Name] ist [offen, geschlossen].