### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Deploy the `openhabGoogleAssistant` (openHAB home automation) function:
 
 * Create a storage bucket (https://console.cloud.google.com/storage/browser)
 * cd openhab-google-assistant/functions
-* gcloud beta functions deploy openhabGoogleAssistant --stage-bucket <BUCKET_NAME> --trigger-http
+* gcloud beta functions deploy openhabGoogleAssistant --runtime nodejs6 --stage-bucket <BUCKET_NAME> --trigger-http
 * This commands will deploy the function to Google Cloud and give you the endpoint address.
 
 Keep the address somewhere, you'll need it (something like `https://us-central1-<PROJECT ID>.cloudfunctions.net/openhabGoogleAssistant`).


### PR DESCRIPTION
Deploy the `openhabGoogleAssistant` (openHAB home automation) function: --runtime is mandatory now to deploy the function. nodejs6 is marked as deprecated but I tested with nodejs8 and get ssl routine error.