### PR TITLE
Edit GA docs to clarify configuration

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -17,7 +17,7 @@ With the Action you can voice control your openHAB items and it supports lights,
 
 ## Requirements
 
-* [openHAB Cloud Connector](http://docs.openhab.org/addons/ios/openhabcloud/readme.html) configured using myopenHAB.org.
+* [openHAB Cloud Connector](http://docs.openhab.org/addons/ios/openhabcloud/readme.html) configured using myopenHAB.org.(Items DO NOT need to be exposed to and will not show up on myopenHAB.org, this is only needed for the IFTTT service!)
 * Google account.
 * Google Home or Google Home mini.
 


### PR DESCRIPTION
Apparently there is a common mistake, also made by me, to expose the items in the configuration of the Cloud Connector through Paper UI. This is not needed for GA to work properly, therefore many people will probably overload the openHAB servers for no functional reason.

Signed-off-by: BennieGe geensben@gmail.com