### PR TITLE
Revamp commands batching to return the full statuses

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -27,7 +27,7 @@ exports.openhabGoogleAssistant = function(request, response) {
 	console.log("openhabGoogleAssistant: Cloud function called:" + JSON.stringify(request.body));
 
 	let requestBody = request.body;
-	if (!requestBody.inputs) {
+	if (!requestBody || !requestBody.inputs) {
 		showError(response, "openhabGoogleAssistant: Missing inputs");
 		return;
 	}

--- a/functions/rest.js
+++ b/functions/rest.js
@@ -44,10 +44,12 @@ function getItem(token, itemName, success, failure) {
 		response.on('end', function () {
 			if (response.statusCode != 200) {
 				console.error('getItem failed for path: ' + options.path +
-						' code: ' + response.statusCode);
+						' code: ' + response.statusCode +
+						' body: ' + body);
 				failure({
 					message: 'Error response ' + response.statusCode
 				});
+				return;
 			}
 			let resp = JSON.parse(body);
 			success(resp);


### PR DESCRIPTION
This should fix the various "cannot reach openHAB" errors (proven on my local setup), during both normal command triggers as well as routine executions.

Here are some specifics of the bugs:
- With any batch of more than one commands (e.g. "turn on living room lights" when you have multiple lights in that room), it doesn't properly batch up the results, and will instead fail the handler, due to double writes to response object.
- Another bug is that `commands` should be an array in the response, instead of a single object. This is what's causing "sorry I can't reach the XXX right now" during routine execution.
- A couple of other minor bugs that manifest only in corner cases.