### PR TITLE
Fixes and tests

### DIFF
--- a/functions/commands.js
+++ b/functions/commands.js
@@ -76,9 +76,7 @@ class GenericCommand {
   }
 
   static handlAuthAck(device = {}, challenge = {}, responseStates = {}) {
-    // check if acknowledge is supported for that command
-    if (!ackSupported.includes(this.type) ||
-      !device.customData || !device.customData.tfaAck || challenge.ack === true) {
+    if (!device.customData || !device.customData.tfaAck || challenge.ack === true) {
       return;
     }
     return {
@@ -103,8 +101,10 @@ class GenericCommand {
         return Promise.resolve();
       }
 
+      const ackWithState = ackSupported.includes(this.type) && device.customData && device.customData.tfaAck && !challenge.ack;
+
       let getItemPromise = Promise.resolve(({}));
-      if (this.requiresItem) {
+      if (this.requiresItem || ackWithState) {
         getItemPromise = apiHandler.getItem(device.id);
       }
 

--- a/functions/commands.js
+++ b/functions/commands.js
@@ -181,7 +181,7 @@ class LockUnlockCommand extends GenericCommand {
 
   static getResponseStates(params) {
     return {
-      on: params.on
+      isLocked: params.lock
     };
   }
 }

--- a/functions/commands.js
+++ b/functions/commands.js
@@ -256,11 +256,12 @@ class VolumeRelativeCommand extends GenericCommand {
   }
 
   static convertParamsToValue(params, item) {
-    return (parseInt(item.state) + params.volumeRelativeLevel).toString();
+    let level = parseInt(item.state) + params.volumeRelativeLevel;
+    return (level < 0 ? 0 : level > 100 ? 100 : level).toString();
   }
 
   static getResponseStates(params, item) {
-    const state = parseInt(item.state) + params.volumeRelativeLevel;
+    const state = parseInt(this.convertParamsToValue(params, item));
     return {
       currentVolume: state,
       isMuted: state === 0

--- a/tests/__snapshots__/openhab.metadata.test.js.snap
+++ b/tests/__snapshots__/openhab.metadata.test.js.snap
@@ -292,3 +292,44 @@ Object {
   ],
 }
 `;
+
+exports[`Test SYNC with Metadata Scene Device 1`] = `
+Object {
+  "devices": Array [
+    Object {
+      "attributes": Object {
+        "sceneReversible": true,
+      },
+      "customData": Object {
+        "deviceType": "action.devices.types.SCENE",
+        "itemType": "Switch",
+        "tfaAck": undefined,
+        "tfaPin": undefined,
+      },
+      "deviceInfo": Object {
+        "hwVersion": "2.5.0",
+        "manufacturer": "openHAB",
+        "model": "Switch",
+        "swVersion": "2.5.0",
+      },
+      "id": "MyScene",
+      "name": Object {
+        "defaultNames": Array [
+          "My Scene",
+        ],
+        "name": "My Scene",
+        "nicknames": Array [
+          "My Scene",
+        ],
+      },
+      "roomHint": undefined,
+      "structureHint": undefined,
+      "traits": Array [
+        "action.devices.traits.Scene",
+      ],
+      "type": "action.devices.types.SCENE",
+      "willReportState": false,
+    },
+  ],
+}
+`;

--- a/tests/openhab.metadata.test.js
+++ b/tests/openhab.metadata.test.js
@@ -129,6 +129,34 @@ describe('Test SYNC with Metadata', () => {
     expect(getItemsMock).toHaveBeenCalledTimes(1);
     expect(payload).toMatchSnapshot();
   });
+
+  test('Scene Device', async () => {
+    const items = [
+      {
+        "state": "OFF",
+        "metadata": {
+          "ga": {
+            "value": "Scene"
+          }
+        },
+        "type": "Switch",
+        "name": "MyScene",
+        "label": "My Scene",
+        "tags": []
+      }
+    ];
+    const getItemsMock = jest.fn();
+    getItemsMock.mockReturnValue(Promise.resolve(items));
+
+    const apiHandler = {
+      getItems: getItemsMock
+    };
+
+    const payload = await new OpenHAB(apiHandler).handleSync();
+
+    expect(getItemsMock).toHaveBeenCalledTimes(1);
+    expect(payload).toMatchSnapshot();
+  });
 });
 
 describe('Test QUERY with Metadata', () => {

--- a/tests/openhab.metadata.test.js
+++ b/tests/openhab.metadata.test.js
@@ -662,4 +662,296 @@ describe('Test EXECUTE with Metadata', () => {
       }]
     });
   });
+
+  test('Lock with required acknowledge', async () => {
+    const item =
+    {
+      "state": "OFF",
+      "type": "Switch",
+      "name": "MyLock",
+      "label": "My Lock",
+      "metadata": {
+        "ga": {
+          "value": "Lock",
+          "config": {
+            "tfaAck": true
+          }
+        }
+      },
+      "tags": []
+    };
+
+    const getItemMock = jest.fn();
+    const sendCommandMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve(item));
+    sendCommandMock.mockReturnValue(Promise.resolve());
+
+    const apiHandler = {
+      getItem: getItemMock,
+      sendCommand: sendCommandMock
+    };
+
+    const commands = [{
+      "devices": [{
+        "customData": {
+          "tfaAck": true
+        },
+        "id": "MyLock"
+      }],
+      "execution": [{
+        "command": "action.devices.commands.LockUnlock",
+        "params": {
+          lock: true
+        }
+      }]
+    }];
+
+    const payload = await new OpenHAB(apiHandler).handleExecute(commands);
+
+    expect(getItemMock).toHaveBeenCalledTimes(1);
+    expect(payload).toStrictEqual({
+      "commands": [{
+        "ids": [
+          "MyLock"
+        ],
+        "states": {
+          "online": true,
+          "isLocked": true
+        },
+        "status": "ERROR",
+        "errorCode": "challengeNeeded",
+        "challengeNeeded": {
+          "type": "ackNeeded",
+        }
+      }]
+    });
+  });
+
+  test('Lock with acknowledged challenge', async () => {
+    const getItemMock = jest.fn();
+    const sendCommandMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve());
+    sendCommandMock.mockReturnValue(Promise.resolve());
+
+    const apiHandler = {
+      getItem: getItemMock,
+      sendCommand: sendCommandMock
+    };
+
+    const commands = [{
+      "devices": [{
+        "customData": {
+          "tfaAck": true
+        },
+        "id": "MyLock"
+      }],
+      "execution": [{
+        "command": "action.devices.commands.LockUnlock",
+        "params": {
+          lock: true
+        },
+        "challenge": {
+          "ack": true
+        }
+      }]
+    }];
+
+    const payload = await new OpenHAB(apiHandler).handleExecute(commands);
+
+    expect(getItemMock).toHaveBeenCalledTimes(0);
+    expect(payload).toStrictEqual({
+      "commands": [{
+        "ids": [
+          "MyLock"
+        ],
+        "states": {
+          "online": true,
+          "isLocked": true
+        },
+        "status": "SUCCESS"
+      }]
+    });
+  });
+
+  test('BrightnessAbsolute with required acknowledge', async () => {
+    const getItemMock = jest.fn();
+    const sendCommandMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve());
+    sendCommandMock.mockReturnValue(Promise.resolve());
+
+    const apiHandler = {
+      getItem: getItemMock,
+      sendCommand: sendCommandMock
+    };
+
+    const commands = [{
+      "devices": [{
+        "customData": {
+          "tfaAck": true
+        },
+        "id": "MyLight"
+      }],
+      "execution": [{
+        "command": "action.devices.commands.BrightnessAbsolute",
+        "params": {
+          "brightness": 30
+        }
+      }]
+    }];
+
+    const payload = await new OpenHAB(apiHandler).handleExecute(commands);
+
+    expect(getItemMock).toHaveBeenCalledTimes(0);
+    expect(payload).toStrictEqual({
+      "commands": [{
+        "ids": [
+          "MyLight"
+        ],
+        "states": {
+          "online": true,
+          "brightness": 30
+        },
+        "status": "ERROR",
+        "errorCode": "challengeNeeded",
+        "challengeNeeded": {
+          "type": "ackNeeded",
+        }
+      }]
+    });
+  });
+
+  test('Arm with required pin', async () => {
+    const getItemMock = jest.fn();
+    const sendCommandMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve());
+    sendCommandMock.mockReturnValue(Promise.resolve());
+
+    const apiHandler = {
+      getItem: getItemMock,
+      sendCommand: sendCommandMock
+    };
+
+    const commands = [{
+      "devices": [{
+        "customData": {
+          "tfaPin": "1234"
+        },
+        "id": "MyAlarm"
+      }],
+      "execution": [{
+        "command": "action.devices.commands.ArmDisarm",
+        "params": {
+          arm: true
+        }
+      }]
+    }];
+
+    const payload = await new OpenHAB(apiHandler).handleExecute(commands);
+
+    expect(getItemMock).toHaveBeenCalledTimes(0);
+    expect(payload).toStrictEqual({
+      "commands": [{
+        "ids": [
+          "MyAlarm"
+        ],
+        "status": "ERROR",
+        "errorCode": "challengeNeeded",
+        "challengeNeeded": {
+          "type": "pinNeeded",
+        }
+      }]
+    });
+  });
+
+  test('Arm with wrong pin', async () => {
+    const getItemMock = jest.fn();
+    const sendCommandMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve());
+    sendCommandMock.mockReturnValue(Promise.resolve());
+
+    const apiHandler = {
+      getItem: getItemMock,
+      sendCommand: sendCommandMock
+    };
+
+    const commands = [{
+      "devices": [{
+        "customData": {
+          "tfaPin": "1234"
+        },
+        "id": "MyAlarm"
+      }],
+      "execution": [{
+        "command": "action.devices.commands.ArmDisarm",
+        "params": {
+          "arm": true
+        },
+        "challenge": {
+          "pin": "3456"
+        }
+      }]
+    }];
+
+    const payload = await new OpenHAB(apiHandler).handleExecute(commands);
+
+    expect(getItemMock).toHaveBeenCalledTimes(0);
+    expect(payload).toStrictEqual({
+      "commands": [{
+        "ids": [
+          "MyAlarm"
+        ],
+        "status": "ERROR",
+        "errorCode": "challengeNeeded",
+        "challengeNeeded": {
+          "type": "challengeFailedPinNeeded"
+        }
+      }]
+    });
+  });
+
+  test('Arm with correct pin', async () => {
+    const getItemMock = jest.fn();
+    const sendCommandMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve());
+    sendCommandMock.mockReturnValue(Promise.resolve());
+
+    const apiHandler = {
+      getItem: getItemMock,
+      sendCommand: sendCommandMock
+    };
+
+    const commands = [{
+      "devices": [{
+        "customData": {
+          "tfaPin": "1234"
+        },
+        "id": "MyAlarm"
+      }],
+      "execution": [{
+        "command": "action.devices.commands.ArmDisarm",
+        "params": {
+          "arm": true
+        },
+        "challenge": {
+          "pin": "1234"
+        }
+      }]
+    }];
+
+    const payload = await new OpenHAB(apiHandler).handleExecute(commands);
+
+    expect(getItemMock).toHaveBeenCalledTimes(0);
+    expect(payload).toStrictEqual({
+      "commands": [{
+        "ids": [
+          "MyAlarm"
+        ],
+        "states": {
+          "online": true,
+          "isArmed": true
+        },
+        "status": "SUCCESS"
+      }]
+    });
+  });
 });

--- a/tests/openhab.test.js
+++ b/tests/openhab.test.js
@@ -147,6 +147,123 @@ describe('Test EXECUTE', () => {
     });
   });
 
+
+  test('volumeRelative Dimmer max overflow', async () => {
+    const item =
+    {
+      "state": "100",
+      "type": "Dimmer",
+      "name": "MySpeaker",
+      "metadata": {
+        "ga": {
+          "value": "Speaker"
+        }
+      }
+    };
+
+    const getItemMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve(item));
+
+    const sendCommandMock = jest.fn();
+    sendCommandMock.mockReturnValue(Promise.resolve());
+
+    const apiHandler = {
+      getItem: getItemMock,
+      sendCommand: sendCommandMock
+    };
+
+    const commands = [{
+      "devices": [{
+        "customData": {
+          "itemType": "Dimmer"
+        },
+        "id": "MySpeaker"
+      }],
+      "execution": [{
+        "command": "action.devices.commands.volumeRelative",
+        "params": {
+          "volumeRelativeLevel": 20
+        }
+      }]
+    }];
+
+    const payload = await new OpenHAB(apiHandler).handleExecute(commands);
+
+    expect(getItemMock).toHaveBeenCalledTimes(1);
+    expect(sendCommandMock).toBeCalledWith('MySpeaker', '100');
+    expect(payload).toStrictEqual({
+      "commands": [{
+        "ids": [
+          "MySpeaker"
+        ],
+        "states": {
+          "currentVolume": 100,
+          "isMuted": false,
+          "online": true
+        },
+        "status": "SUCCESS"
+      }]
+    });
+  });
+
+  test('volumeRelative Dimmer min overflow', async () => {
+    const item =
+    {
+      "state": "10",
+      "type": "Dimmer",
+      "name": "MySpeaker",
+      "metadata": {
+        "ga": {
+          "value": "Speaker"
+        }
+      }
+    };
+
+    const getItemMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve(item));
+
+    const sendCommandMock = jest.fn();
+    sendCommandMock.mockReturnValue(Promise.resolve());
+
+    const apiHandler = {
+      getItem: getItemMock,
+      sendCommand: sendCommandMock
+    };
+
+    const commands = [{
+      "devices": [{
+        "customData": {
+          "itemType": "Dimmer"
+        },
+        "id": "MySpeaker"
+      }],
+      "execution": [{
+        "command": "action.devices.commands.volumeRelative",
+        "params": {
+          "volumeRelativeLevel": -20
+        }
+      }]
+    }];
+
+    const payload = await new OpenHAB(apiHandler).handleExecute(commands);
+
+    expect(getItemMock).toHaveBeenCalledTimes(1);
+    expect(sendCommandMock).toBeCalledWith('MySpeaker', '0');
+    expect(payload).toStrictEqual({
+      "commands": [{
+        "ids": [
+          "MySpeaker"
+        ],
+        "states": {
+          "currentVolume": 0,
+          "isMuted": true,
+          "online": true
+        },
+        "status": "SUCCESS"
+      }]
+    });
+  });
+
   test('OpenClose Rollershutter', async () => {
     const getItemMock = jest.fn();
     const sendCommandMock = jest.fn();


### PR DESCRIPTION
With this PR I fix three minor issues:

- The _LockUnlock_ trait would return the wrong response state. Changed "on" to "isLocked".
- The _volumeRelative_ trait would allow values below 0 and above 100. Fixed by checking those boundaries.
- The TFA acknowledge challenge was only applied to a list of traits, while Google now officially supports all devices and traits. Fixed by adjusting the check.

Furthermore, I have added a lot of tests for all those scenarios.