### PR TITLE
Add user-configurable thermostat mode map

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,6 @@ To change the temperature unit to Fahrenheit, add the config option `[ useFahren
 There must be at least three items as members of the group:
 
 * (Mandatory) Mode: Number (Zwave THERMOSTAT_MODE Format) or String (off, heat, cool, on, ...). `{ ga="thermostatMode" }`
-  * you can define the supported modes with the config option `[ modes="on,off,heat,cool" ]`
 * (Mandatory) Temperature Ambient: Number. `{ ga="thermostatTemperatureAmbient" }`
 * (Mandatory) Temperature Setpoint: Number. `{ ga="thermostatTemperatureSetpoint" }`
 * (Optional) Humidity Setpoint High: Number. `{ ga="thermostatTemperatureSetpointHigh" }`
@@ -292,6 +291,10 @@ There must be at least three items as members of the group:
 * (Optional) Humidity Ambient: Number. `{ ga="thermostatHumidityAmbient" }`
 
 If your thermostat does not have a mode, you should create one and manually assign a value (e.g. heat, cool, on, etc.) to have proper functionality.
+
+To map the [default thermostat modes of Google](https://developers.google.com/assistant/smarthome/traits/temperaturesetting.html) (on, off, heat, cool, etc.) to custom ones for your specific setup, you can use the _modes_ config option on the thermostat group.
+E.g. `[ modes="off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto" ]` will enable the following five modes in Google Home `"off, heat, eco, on, auto"` that will be translated to `"OFF, COMFORT, ECO, ON, auto"`. You can specify alternative conversions using the colon sign, so that in the former example "BOOST" in openHAB would also be translated to "heat" in Google. For the translation of Google modes to openHAB always the first option after the equal sign is used.
+By default the integration will provide `"off,heat,cool,on,heatcool,auto,eco"`.
 
 You can also set up a Thermostat for using it as a temperature sensor. To do so, create a Thermostat group and only add one item member as "thermostatTemperatureAmbient".
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -129,7 +129,6 @@ To change the temperature unit to Fahrenheit, add the config option `[ useFahren
 There must be at least three items as members of the group:
 
 * (Mandatory) Mode: Number (Zwave THERMOSTAT_MODE Format) or String (off, heat, cool, on, ...). `{ ga="thermostatMode" }`
-  * you can define the supported modes with the config option `[ modes="on,off,heat,cool" ]`
 * (Mandatory) Temperature Ambient: Number. `{ ga="thermostatTemperatureAmbient" }`
 * (Mandatory) Temperature Setpoint: Number. `{ ga="thermostatTemperatureSetpoint" }`
 * (Optional) Humidity Setpoint High: Number. `{ ga="thermostatTemperatureSetpointHigh" }`
@@ -137,6 +136,10 @@ There must be at least three items as members of the group:
 * (Optional) Humidity Ambient: Number. `{ ga="thermostatHumidityAmbient" }`
 
 If your thermostat does not have a mode, you should create one and manually assign a value (e.g. heat, cool, on, etc.) to have proper functionality.
+
+To map the [default thermostat modes of Google](https://developers.google.com/assistant/smarthome/traits/temperaturesetting.html) (on, off, heat, cool, etc.) to custom ones for your specific setup, you can use the _modes_ config option on the thermostat group.
+E.g. `[ modes="off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto" ]` will enable the following five modes in Google Home `"off, heat, eco, on, auto"` that will be translated to `"OFF, COMFORT, ECO, ON, auto"`. You can specify alternative conversions using the colon sign, so that in the former example "BOOST" in openHAB would also be translated to "heat" in Google. For the translation of Google modes to openHAB always the first option after the equal sign is used.
+By default the integration will provide `"off,heat,cool,on,heatcool,auto,eco"`.
 
 You can also set up a Thermostat for using it as a temperature sensor. To do so, create a Thermostat group and only add one item member as "thermostatTemperatureAmbient".
 

--- a/functions/commands.js
+++ b/functions/commands.js
@@ -53,8 +53,8 @@ class GenericCommand {
     return {};
   }
 
-  static getItemName(device = {}) {
-    return device.id;
+  static getItemName(item = {}) {
+    return item.name;
   }
 
   static get requiresItem() {
@@ -103,7 +103,7 @@ class GenericCommand {
 
       const ackWithState = ackSupported.includes(this.type) && device.customData && device.customData.tfaAck && !challenge.ack;
 
-      let getItemPromise = Promise.resolve(({}));
+      let getItemPromise = Promise.resolve(({ name: device.id }));
       if (this.requiresItem || ackWithState) {
         getItemPromise = apiHandler.getItem(device.id);
       }
@@ -120,7 +120,7 @@ class GenericCommand {
           return;
         }
 
-        const targetItem = this.getItemName(device);
+        const targetItem = this.getItemName(item);
         const targetValue = this.convertParamsToValue(params, item, device);
         let sendCommandPromise = Promise.resolve();
         if (typeof targetItem === 'string' && typeof targetValue === 'string') {
@@ -480,11 +480,12 @@ class ThermostatTemperatureSetpointCommand extends GenericCommand {
     return true;
   }
 
-  static getItemName(device) {
-    if (!device.customData || !device.customData.thermostatTemperatureSetpoint) {
+  static getItemName(item) {
+    const members = Thermostat.getMembers(item);
+    if (!members.thermostatTemperatureSetpoint) {
       throw { statusCode: 400 };
     }
-    return device.customData.thermostatTemperatureSetpoint;
+    return members.thermostatTemperatureSetpoint.name;
   }
 
   static convertParamsToValue(params, item) {
@@ -515,11 +516,12 @@ class ThermostatTemperatureSetpointHighCommand extends GenericCommand {
     return true;
   }
 
-  static getItemName(device) {
-    if (!device.customData || !device.customData.thermostatTemperatureSetpointHigh) {
+  static getItemName(item) {
+    const members = Thermostat.getMembers(item);
+    if (!members.thermostatTemperatureSetpointHigh) {
       throw { statusCode: 400 };
     }
-    return device.customData.thermostatTemperatureSetpointHigh;
+    return members.thermostatTemperatureSetpointHigh.name;
   }
 
   static convertParamsToValue(params, item) {
@@ -550,11 +552,12 @@ class ThermostatTemperatureSetpointLowCommand extends GenericCommand {
     return true;
   }
 
-  static getItemName(device) {
-    if (!device.customData || !device.customData.thermostatTemperatureSetpointLow) {
+  static getItemName(item) {
+    const members = Thermostat.getMembers(item);
+    if (!members.thermostatTemperatureSetpointLow) {
       throw { statusCode: 400 };
     }
-    return device.customData.thermostatTemperatureSetpointLow;
+    return members.thermostatTemperatureSetpointLow.name;
   }
 
   static convertParamsToValue(params, item) {
@@ -585,18 +588,15 @@ class ThermostatSetModeCommand extends GenericCommand {
     return true;
   }
 
-  static getItemName(device) {
-    if (!device.customData || !device.customData.thermostatMode) {
-      throw { statusCode: 400 };
-    }
-    return device.customData.thermostatMode;
-  }
-
-  static convertParamsToValue(params, item) {
+  static getItemName(item) {
     const members = Thermostat.getMembers(item);
     if (!members.thermostatMode) {
       throw { statusCode: 400 };
     }
+    return members.thermostatMode.name;
+  }
+
+  static convertParamsToValue(params, item) {
     return Thermostat.translateModeToOpenhab(item, params.thermostatMode);
   }
 

--- a/functions/commands.js
+++ b/functions/commands.js
@@ -597,7 +597,7 @@ class ThermostatSetModeCommand extends GenericCommand {
     if (!members.thermostatMode) {
       throw { statusCode: 400 };
     }
-    return Thermostat.denormalizeThermostatMode(members.thermostatMode.state, params.thermostatMode);
+    return Thermostat.translateModeToOpenhab(item, params.thermostatMode);
   }
 
   static getResponseStates(params, item) {

--- a/functions/commands.js
+++ b/functions/commands.js
@@ -482,7 +482,7 @@ class ThermostatTemperatureSetpointCommand extends GenericCommand {
 
   static getItemName(item) {
     const members = Thermostat.getMembers(item);
-    if (!members.thermostatTemperatureSetpoint) {
+    if (!('thermostatTemperatureSetpoint' in members)) {
       throw { statusCode: 400 };
     }
     return members.thermostatTemperatureSetpoint.name;
@@ -518,7 +518,7 @@ class ThermostatTemperatureSetpointHighCommand extends GenericCommand {
 
   static getItemName(item) {
     const members = Thermostat.getMembers(item);
-    if (!members.thermostatTemperatureSetpointHigh) {
+    if (!('thermostatTemperatureSetpointHigh' in members)) {
       throw { statusCode: 400 };
     }
     return members.thermostatTemperatureSetpointHigh.name;
@@ -554,7 +554,7 @@ class ThermostatTemperatureSetpointLowCommand extends GenericCommand {
 
   static getItemName(item) {
     const members = Thermostat.getMembers(item);
-    if (!members.thermostatTemperatureSetpointLow) {
+    if (!('thermostatTemperatureSetpointLow' in members)) {
       throw { statusCode: 400 };
     }
     return members.thermostatTemperatureSetpointLow.name;
@@ -590,7 +590,7 @@ class ThermostatSetModeCommand extends GenericCommand {
 
   static getItemName(item) {
     const members = Thermostat.getMembers(item);
-    if (!members.thermostatMode) {
+    if (!('thermostatMode' in members)) {
       throw { statusCode: 400 };
     }
     return members.thermostatMode.name;

--- a/functions/devices.js
+++ b/functions/devices.js
@@ -596,15 +596,6 @@ class Thermostat extends GenericDevice {
     return attributes;
   }
 
-  static getMetadata(item) {
-    const metadata = super.getMetadata(item);
-    const members = this.getMembers(item);
-    for (const member in members) {
-      metadata.customData[member] = members[member].name;
-    }
-    return metadata;
-  }
-
   static checkItemType(item) {
     return item.type === 'Group';
   }
@@ -669,7 +660,7 @@ class Thermostat extends GenericDevice {
     const config = getConfig(item);
     let modes = ['off', 'heat', 'cool', 'on', 'heatcool', 'auto', 'eco'];
     if ('modes' in config) {
-      modes = getConfig(item).modes.split(',');
+      modes = config.modes.split(',');
     }
     const modeMap = {};
     modes.forEach(pair => {

--- a/functions/devices.js
+++ b/functions/devices.js
@@ -19,7 +19,7 @@
  */
 
 const hasTag = (item = {}, tag = '') => {
-  return item.tags && item.tags.map(t => t.toLowerCase()).includes(tag.toLowerCase());
+  return item.tags && item.tags.map(t => t.toLowerCase()).includes(tag.toLowerCase()) || false;
 };
 
 const getDeviceForItem = (item = {}) => {
@@ -56,9 +56,9 @@ class GenericDevice {
       type: this.type,
       traits: this.traits,
       name: {
-        name: config.name || item.label,
-        defaultNames: [config.name || item.label],
-        nicknames: [config.name || item.label, ...(item.metadata && item.metadata.synonyms ? item.metadata.synonyms.value.split(',') : [])]
+        name: config.name || item.label,
+        defaultNames: [config.name || item.label],
+        nicknames: [config.name || item.label, ...(item.metadata && item.metadata.synonyms ? item.metadata.synonyms.value.split(',') : [])]
       },
       willReportState: false,
       roomHint: config.roomHint,
@@ -591,7 +591,7 @@ class Thermostat extends GenericDevice {
       !('thermostatTemperatureSetpoint' in members)) {
       attributes.queryOnlyTemperatureSetting = true;
     } else {
-      attributes.availableThermostatModes = getConfig(item).modes || 'off,heat,cool,on,heatcool';
+      attributes.availableThermostatModes = Object.keys(this.getModeMap(item)).join(',');
     }
     return attributes;
   }
@@ -602,7 +602,6 @@ class Thermostat extends GenericDevice {
     for (const member in members) {
       metadata.customData[member] = members[member].name;
     }
-    metadata.customData.useFahrenheit = this.usesFahrenheit(item);
     return metadata;
   }
 
@@ -615,7 +614,7 @@ class Thermostat extends GenericDevice {
     const members = this.getMembers(item);
     for (const member in members) {
       if (member == 'thermostatMode') {
-        state[member] = this.normalizeThermostatMode(members[member].state);
+        state[member] = this.translateModeToGoogle(item, members[member].state);
       } else {
         state[member] = Number(parseFloat(members[member].state).toFixed(1));
         if (member.indexOf('Temperature') > 0 && this.usesFahrenheit(item)) {
@@ -666,28 +665,36 @@ class Thermostat extends GenericDevice {
     return getConfig(item).useFahrenheit === true || hasTag(item, 'Fahrenheit');
   }
 
-  static get _modeMap() {
-    return ['off', 'heat', 'cool', 'on', 'heatcool', 'auto'];
-  }
-
-  static normalizeThermostatMode(mode) {
-    let normalizedMode = mode.replace('-', '');
-    const intMode = Number(mode);
-    if (!isNaN(intMode)) {
-      normalizedMode = intMode in this._modeMap ? this._modeMap[intMode] : 'off';
+  static getModeMap(item) {
+    const config = getConfig(item);
+    let modes = ['off', 'heat', 'cool', 'on', 'heatcool', 'auto', 'eco'];
+    if ('modes' in config) {
+      modes = getConfig(item).modes.split(',');
     }
-    return normalizedMode.toLowerCase();
+    const modeMap = {};
+    modes.forEach(pair => {
+      const [ key, value ] = pair.split('=');
+      modeMap[key] = value ? value.split(':') : [key];
+    });
+    return modeMap;
   }
 
-  static denormalizeThermostatMode(oldMode, newMode) {
-    let denormalizedMode = newMode.replace('-', '');
-    if (!isNaN(Number(oldMode))) {
-      denormalizedMode = this._modeMap.indexOf(newMode);
-      if (denormalizedMode < 0) {
-        denormalizedMode = 0;
+  static translateModeToOpenhab(item, mode) {
+    const modeMap = this.getModeMap(item);
+    if (mode in modeMap) {
+      return modeMap[mode][0];
+    }
+    throw { statusCode: 400 };
+  }
+
+  static translateModeToGoogle(item, mode) {
+    const modeMap = this.getModeMap(item);
+    for (const key in modeMap) {
+      if (modeMap[key].includes(mode)) {
+        return key;
       }
     }
-    return denormalizedMode.toString();
+    return 'on';
   }
 
   static convertToFahrenheit(value = 0) {

--- a/tests/devices.metadata.test.js
+++ b/tests/devices.metadata.test.js
@@ -17,7 +17,7 @@ describe('Test Switch Devices with Metadata', () => {
       on: true
     });
   });
-  
+
   test('Valve Switch Type', () => {
     const item = {
       type: 'Switch',
@@ -282,7 +282,7 @@ describe('Test Thermostat Device with Metadata', () => {
         }
       }
     })).toStrictEqual({
-      'availableThermostatModes': 'off,heat,cool,on,heatcool',
+      'availableThermostatModes': 'off,heat,cool,on,heatcool,auto,eco',
       'thermostatTemperatureUnit': 'F',
     });
 
@@ -299,6 +299,202 @@ describe('Test Thermostat Device with Metadata', () => {
       'availableThermostatModes': 'on,off',
       'thermostatTemperatureUnit': 'C',
     });
+
+    expect(Devices.Thermostat.getAttributes({
+      metadata: {
+        ga: {
+          value: 'Thermostat',
+          config: {
+            modes: 'off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto'
+          }
+        }
+      }
+    })).toStrictEqual({
+      'availableThermostatModes': 'off,heat,eco,on,auto',
+      'thermostatTemperatureUnit': 'C',
+    });
+  });
+
+  test('getModeMap', () => {
+    expect(Devices.Thermostat.getModeMap({
+      metadata: {
+        ga: {
+          value: 'Thermostat'
+        }
+      }
+    })).toStrictEqual({
+      'off': ['off'],
+      'heat': ['heat'],
+      'cool': ['cool'],
+      'on': ['on'],
+      'heatcool': ['heatcool'],
+      'auto': ['auto'],
+      'eco': ['eco']
+    });
+
+    expect(Devices.Thermostat.getModeMap({
+      metadata: {
+        ga: {
+          value: 'Thermostat',
+          config: {
+            modes: 'on,off,heat,cool'
+          }
+        }
+      }
+    })).toStrictEqual({
+      'on': ['on'],
+      'off': ['off'],
+      'heat': ['heat'],
+      'cool': ['cool']
+    });
+
+    expect(Devices.Thermostat.getModeMap({
+      metadata: {
+        ga: {
+          value: 'Thermostat',
+          config: {
+            modes: 'off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto'
+          }
+        }
+      }
+    })).toStrictEqual({
+      'off': ['OFF', 'WINDOW_OPEN'],
+      'heat': ['COMFORT', 'BOOST'],
+      'eco': ['ECO'],
+      'on': ['ON'],
+      'auto': ['auto']
+    });
+  });
+
+  test('translateModeToGoogle', () => {
+    expect(Devices.Thermostat.translateModeToGoogle({
+      metadata: {
+        ga: {
+          value: 'Thermostat',
+          config: {
+            modes: 'off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto'
+          }
+        }
+      }
+    }, 'COMFORT')).toBe('heat');
+
+    expect(Devices.Thermostat.translateModeToGoogle({
+      metadata: {
+        ga: {
+          value: 'Thermostat',
+          config: {
+            modes: 'off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto'
+          }
+        }
+      }
+    }, 'WINDOW_OPEN')).toBe('off');
+  });
+
+  test('translateModeToOpenhab', () => {
+    expect(Devices.Thermostat.translateModeToOpenhab({
+      metadata: {
+        ga: {
+          value: 'Thermostat',
+          config: {
+            modes: 'off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto'
+          }
+        }
+      }
+    }, 'heat')).toBe('COMFORT');
+
+    expect(Devices.Thermostat.translateModeToOpenhab({
+      metadata: {
+        ga: {
+          value: 'Thermostat',
+          config: {
+            modes: 'off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto'
+          }
+        }
+      }
+    }, 'auto')).toBe('auto');
+  });
+
+  test('getMetadata', () => {
+    expect(Devices.Thermostat.getMetadata(
+      {
+        name: 'MyItem',
+        label: 'MyThermostat',
+        type: 'Group',
+        metadata: {
+          ga: {
+            value: 'Thermostat',
+            config: {
+              name: 'My Thermostat',
+              modes: 'off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto=AUTOMATIC'
+            }
+          }
+        },
+        members: [{
+          name: 'Ambient',
+          type: 'Number',
+          metadata: {
+            ga: {
+              value: 'thermostatTemperatureAmbient'
+            }
+          },
+          state: '10'
+        }, {
+          name: 'SetPoint',
+          type: 'Number',
+          metadata: {
+            ga: {
+              value: 'thermostatTemperatureSetpoint'
+            }
+          },
+          state: '20'
+        }, {
+          name: 'Mode',
+          type: 'Number',
+          metadata: {
+            ga: {
+              value: 'thermostatMode'
+            }
+          },
+          state: 'off'
+        }]
+      })).toStrictEqual({
+        "attributes": {
+          "availableThermostatModes": "off,heat,eco,on,auto",
+          "thermostatTemperatureUnit": "C"
+        },
+        "customData": {
+          "deviceType": "action.devices.types.THERMOSTAT",
+          "itemType": "Group",
+          "tfaAck": undefined,
+          "tfaPin": undefined,
+          "thermostatMode": "Mode",
+          "thermostatTemperatureAmbient": "Ambient",
+          "thermostatTemperatureSetpoint": "SetPoint"
+        },
+        "roomHint": undefined,
+        "structureHint": undefined,
+        "deviceInfo": {
+          "hwVersion": "2.5.0",
+          "manufacturer": "openHAB",
+          "model": "Group",
+          "swVersion": "2.5.0",
+        },
+        "id": "MyItem",
+        "name": {
+          "defaultNames": [
+            "My Thermostat",
+          ],
+          "name": "My Thermostat",
+          "nicknames": [
+            "My Thermostat",
+          ]
+        },
+        "traits": [
+          "action.devices.traits.TemperatureSetting",
+        ],
+        "type": "action.devices.types.THERMOSTAT",
+        "willReportState": false
+      });
   });
 
   test('getState', () => {
@@ -356,7 +552,10 @@ describe('Test Thermostat Device with Metadata', () => {
       type: 'Group',
       metadata: {
         ga: {
-          value: 'Thermostat'
+          value: 'Thermostat',
+          config: {
+            modes: 'heat=1,off=2'
+          }
         }
       },
       members: [{

--- a/tests/devices.metadata.test.js
+++ b/tests/devices.metadata.test.js
@@ -466,10 +466,7 @@ describe('Test Thermostat Device with Metadata', () => {
           "deviceType": "action.devices.types.THERMOSTAT",
           "itemType": "Group",
           "tfaAck": undefined,
-          "tfaPin": undefined,
-          "thermostatMode": "Mode",
-          "thermostatTemperatureAmbient": "Ambient",
-          "thermostatTemperatureSetpoint": "SetPoint"
+          "tfaPin": undefined
         },
         "roomHint": undefined,
         "structureHint": undefined,

--- a/tests/devices.tags.test.js
+++ b/tests/devices.tags.test.js
@@ -203,7 +203,7 @@ describe('Test Thermostat Device with Tags', () => {
         'Fahrenheit'
       ]
     })).toStrictEqual({
-      'availableThermostatModes': 'off,heat,cool,on,heatcool',
+      'availableThermostatModes': 'off,heat,cool,on,heatcool,auto,eco',
       'thermostatTemperatureUnit': 'F',
     });
 
@@ -212,7 +212,7 @@ describe('Test Thermostat Device with Tags', () => {
         'Thermostat'
       ]
     })).toStrictEqual({
-      'availableThermostatModes': 'off,heat,cool,on,heatcool',
+      'availableThermostatModes': 'off,heat,cool,on,heatcool,auto,eco',
       'thermostatTemperatureUnit': 'C',
     });
   });
@@ -278,7 +278,7 @@ describe('Test Thermostat Device with Tags', () => {
         tags: [
           'HeatingCoolingMode'
         ],
-        state: '1'
+        state: 'heat'
       }, {
         type: 'Number',
         tags: [

--- a/tests/devices.test.js
+++ b/tests/devices.test.js
@@ -10,26 +10,4 @@ describe('Test Thermostat Device', () => {
     expect(Devices.Thermostat.convertToFahrenheit(10.0)).toEqual(50);
     expect(Devices.Thermostat.convertToFahrenheit(0.0)).toEqual(32);
   });
-
-  test('normalizeThermostatMode', () => {
-    expect(Devices.Thermostat.normalizeThermostatMode('heat')).toEqual('heat');
-    expect(Devices.Thermostat.normalizeThermostatMode('off')).toEqual('off');
-    expect(Devices.Thermostat.normalizeThermostatMode('on')).toEqual('on');
-    expect(Devices.Thermostat.normalizeThermostatMode('heat-cool')).toEqual('heatcool');
-    expect(Devices.Thermostat.normalizeThermostatMode('0')).toEqual('off');
-    expect(Devices.Thermostat.normalizeThermostatMode('1')).toEqual('heat');
-    expect(Devices.Thermostat.normalizeThermostatMode('2')).toEqual('cool');
-    expect(Devices.Thermostat.normalizeThermostatMode('3')).toEqual('on');
-  });
-
-  test('denormalizeThermostatMode', () => {
-    expect(Devices.Thermostat.denormalizeThermostatMode('heat', 'heat')).toEqual('heat');
-    expect(Devices.Thermostat.denormalizeThermostatMode('heat', 'off')).toEqual('off');
-    expect(Devices.Thermostat.denormalizeThermostatMode('heat', 'on')).toEqual('on');
-    expect(Devices.Thermostat.denormalizeThermostatMode('heat', 'heatcool')).toEqual('heatcool');
-    expect(Devices.Thermostat.denormalizeThermostatMode('0', 'off')).toEqual('0');
-    expect(Devices.Thermostat.denormalizeThermostatMode('1', 'heat')).toEqual('1');
-    expect(Devices.Thermostat.denormalizeThermostatMode('2', 'cool')).toEqual('2');
-    expect(Devices.Thermostat.denormalizeThermostatMode('3', 'on')).toEqual('3');
-  });
 });

--- a/tests/openhab.metadata.test.js
+++ b/tests/openhab.metadata.test.js
@@ -430,9 +430,6 @@ describe('Test EXECUTE with Metadata', () => {
 
     const commands = [{
       "devices": [{
-        "customData": {
-          "thermostatTemperatureSetpoint": "MyTargetTemperature"
-        },
         "id": "MyThermostat"
       }],
       "execution": [{
@@ -606,10 +603,6 @@ describe('Test EXECUTE with Metadata', () => {
 
     const commands = [{
       "devices": [{
-        "customData": {
-          "thermostatTemperatureSetpointHigh": "MyTargetTemperatureHigh",
-          "thermostatTemperatureSetpointLow": "MyTargetTemperatureLow"
-        },
         "id": "MyThermostat"
       }],
       "execution": [{
@@ -678,6 +671,7 @@ describe('Test EXECUTE with Metadata', () => {
         },
         state: '10'
       }, {
+        name: 'MyMode',
         type: 'Number',
         metadata: {
           ga: {
@@ -708,9 +702,6 @@ describe('Test EXECUTE with Metadata', () => {
 
     const commands = [{
       "devices": [{
-        "customData": {
-          "thermostatMode": "MyMode"
-        },
         "id": "MyThermostat"
       }],
       "execution": [{
@@ -769,6 +760,7 @@ describe('Test EXECUTE with Metadata', () => {
         },
         state: '10'
       }, {
+        name: 'MyMode',
         type: 'Number',
         metadata: {
           ga: {
@@ -799,9 +791,6 @@ describe('Test EXECUTE with Metadata', () => {
 
     const commands = [{
       "devices": [{
-        "customData": {
-          "thermostatMode": "MyMode"
-        },
         "id": "MyThermostat"
       }],
       "execution": [{

--- a/tests/openhab.tags.test.js
+++ b/tests/openhab.tags.test.js
@@ -196,7 +196,7 @@ describe('Test EXECUTE with Tags', () => {
         tags: [
           'HeatingCoolingMode'
         ],
-        state: '1'
+        state: 'heat'
       }, {
         type: 'Number',
         tags: [

--- a/tests/openhab.tags.test.js
+++ b/tests/openhab.tags.test.js
@@ -192,7 +192,7 @@ describe('Test EXECUTE with Tags', () => {
         ],
         state: '10'
       }, {
-        type: 'Number',
+        type: 'String',
         tags: [
           'HeatingCoolingMode'
         ],
@@ -218,9 +218,6 @@ describe('Test EXECUTE with Tags', () => {
 
     const commands = [{
       "devices": [{
-        "customData": {
-          "thermostatTemperatureSetpoint": "MyTargetTemperature"
-        },
         "id": "MyThermostat"
       }],
       "execution": [{
@@ -246,6 +243,87 @@ describe('Test EXECUTE with Tags', () => {
           "thermostatMode": "heat",
           "thermostatTemperatureAmbient": -12.2,
           "thermostatTemperatureSetpoint": 25
+        },
+        "status": "SUCCESS"
+      }]
+    });
+  });
+
+  test('ThermostatSetModeCommand', async () => {
+    const item =
+    {
+      "state": "NULL",
+      "type": "Group",
+      "name": "MyThermostat",
+      "label": "Thermostat",
+      "tags": [
+        "Thermostat"
+      ],
+      "members": [{
+        type: 'Number',
+        tags: [
+          'CurrentTemperature'
+        ],
+        state: '10'
+      }, {
+        type: 'Number',
+        tags: [
+          'TargetTemperature'
+        ],
+        state: '10'
+      }, {
+        name: 'MyHeatingCoolingMode',
+        type: 'String',
+        tags: [
+          'HeatingCoolingMode'
+        ],
+        state: 'cool'
+      }, {
+        type: 'Number',
+        tags: [
+          'CurrentHumidity'
+        ],
+        state: '50'
+      }]
+    };
+
+    const getItemMock = jest.fn();
+    const sendCommandMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve(item));
+    sendCommandMock.mockReturnValue(Promise.resolve());
+
+    const apiHandler = {
+      getItem: getItemMock,
+      sendCommand: sendCommandMock
+    };
+
+    const commands = [{
+      "devices": [{
+        "id": "MyThermostat"
+      }],
+      "execution": [{
+        "command": "action.devices.commands.ThermostatSetMode",
+        "params": {
+          "thermostatMode": "heat"
+        }
+      }]
+    }];
+
+    const payload = await new OpenHAB(apiHandler).handleExecute(commands);
+
+    expect(getItemMock).toHaveBeenCalledTimes(1);
+    expect(sendCommandMock).toBeCalledWith('MyHeatingCoolingMode', 'heat');
+    expect(payload).toStrictEqual({
+      "commands": [{
+        "ids": [
+          "MyThermostat"
+        ],
+        "states": {
+          "online": true,
+          "thermostatHumidityAmbient": 50,
+          "thermostatMode": "heat",
+          "thermostatTemperatureAmbient": 10,
+          "thermostatTemperatureSetpoint": 10
         },
         "status": "SUCCESS"
       }]


### PR DESCRIPTION
With this PR we add the option for the user to configure a custom thermostat mode mapping.
Since a lot of people are using different setups with different thermostat modes, the default mapping to numbers or the google default modes were not sufficient.
The users had to write their own translations with rules and transformation maps.

This is now not required anymore, since the user will now be able to state a metadata config option called "modes". You can state custom mode string as well as numbers.
E.g. `[ modes="off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto" ]`.
This is used to translate the thermostat mode in both directions.
The example will enable the following five modes in Google Home `"off, heat, eco, on, auto"` that will be translated to `"OFF, COMFORT, ECO, ON, auto"`.
You can specify alternative conversions using the colon sign, so that in the former example "BOOST" in openHAB would also be translated to "heat" in Google. For the translation of Google modes to openHAB always the first option after the equal sign is used.
By default the integration will provide `"off,heat,cool,on,heatcool,auto,eco"`.

## ATTENTION!
This will break the default mapping to numbers (0-5) and vice versa.
The previous behavior can be reconfigured with metadata with:
`[ modes="off=0,heat=1,cool=2,on=3,heatcool=4,auto=5" ]`

**Configuration using tags will not support a conversion anymore!**