### PR TITLE
Store correct itemType for groups

### DIFF
--- a/functions/devices.js
+++ b/functions/devices.js
@@ -71,7 +71,7 @@ class GenericDevice {
       },
       attributes: this.getAttributes(item),
       customData: {
-        itemType: item.type,
+        itemType: item.type === 'Group' ? item.groupType : item.type,
         deviceType: this.type,
         tfaAck: config.tfaAck,
         tfaPin: config.tfaPin

--- a/tests/__snapshots__/openhab.metadata.test.js.snap
+++ b/tests/__snapshots__/openhab.metadata.test.js.snap
@@ -192,7 +192,7 @@ Object {
       "attributes": Object {},
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
-        "itemType": "Group",
+        "itemType": "Switch",
         "tfaAck": undefined,
         "tfaPin": undefined,
       },
@@ -224,7 +224,7 @@ Object {
       "attributes": Object {},
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
-        "itemType": "Group",
+        "itemType": "Dimmer",
         "tfaAck": undefined,
         "tfaPin": undefined,
       },
@@ -259,7 +259,7 @@ Object {
       },
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
-        "itemType": "Group",
+        "itemType": "Color",
         "tfaAck": undefined,
         "tfaPin": undefined,
       },

--- a/tests/__snapshots__/openhab.tags.test.js.snap
+++ b/tests/__snapshots__/openhab.tags.test.js.snap
@@ -108,7 +108,7 @@ Object {
       "attributes": Object {},
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
-        "itemType": "Group",
+        "itemType": "Switch",
         "tfaAck": undefined,
         "tfaPin": undefined,
       },
@@ -140,7 +140,7 @@ Object {
       "attributes": Object {},
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
-        "itemType": "Group",
+        "itemType": "Dimmer",
         "tfaAck": undefined,
         "tfaPin": undefined,
       },
@@ -175,7 +175,7 @@ Object {
       },
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
-        "itemType": "Group",
+        "itemType": "Color",
         "tfaAck": undefined,
         "tfaPin": undefined,
       },

--- a/tests/openhab.metadata.test.js
+++ b/tests/openhab.metadata.test.js
@@ -954,4 +954,92 @@ describe('Test EXECUTE with Metadata', () => {
       }]
     });
   });
+
+  test('OpenClose Blinds Group as Rollershutter', async () => {
+    const getItemMock = jest.fn();
+    const sendCommandMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve());
+    sendCommandMock.mockReturnValue(Promise.resolve());
+
+    const apiHandler = {
+      getItem: getItemMock,
+      sendCommand: sendCommandMock
+    };
+
+    const commands = [{
+      "devices": [{
+        "id": "MyBlinds",
+        "customData": {
+          "itemType": "Rollershutter"
+        }
+      }],
+      "execution": [{
+        "command": "action.devices.commands.OpenClose",
+        "params": {
+          "openPercent": 0
+        }
+      }]
+    }];
+
+    const payload = await new OpenHAB(apiHandler).handleExecute(commands);
+
+    expect(getItemMock).toHaveBeenCalledTimes(0);
+    expect(sendCommandMock).toBeCalledWith('MyBlinds', 'DOWN');
+    expect(payload).toStrictEqual({
+      "commands": [{
+        "ids": [
+          "MyBlinds"
+        ],
+        "states": {
+          "online": true,
+          "openPercent": 0
+        },
+        "status": "SUCCESS"
+      }]
+    });
+  });
+
+  test('OpenClose Blinds Group as Switch', async () => {
+    const getItemMock = jest.fn();
+    const sendCommandMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve());
+    sendCommandMock.mockReturnValue(Promise.resolve());
+
+    const apiHandler = {
+      getItem: getItemMock,
+      sendCommand: sendCommandMock
+    };
+
+    const commands = [{
+      "devices": [{
+        "id": "MyBlinds",
+        "customData": {
+          "itemType": "Switch"
+        }
+      }],
+      "execution": [{
+        "command": "action.devices.commands.OpenClose",
+        "params": {
+          "openPercent": 0
+        }
+      }]
+    }];
+
+    const payload = await new OpenHAB(apiHandler).handleExecute(commands);
+
+    expect(getItemMock).toHaveBeenCalledTimes(0);
+    expect(sendCommandMock).toBeCalledWith('MyBlinds', 'OFF');
+    expect(payload).toStrictEqual({
+      "commands": [{
+        "ids": [
+          "MyBlinds"
+        ],
+        "states": {
+          "online": true,
+          "openPercent": 0
+        },
+        "status": "SUCCESS"
+      }]
+    });
+  });
 });


### PR DESCRIPTION
Fixes the issue reported in #135.

For groups the "wrong" item type was stored in the custom data, which was "group" instead of the actual group type.