### PR TITLE
Fix thermostat group documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,8 @@ There must be at least three items as members of the group:
 * (Mandatory) Mode: Number (Zwave THERMOSTAT_MODE Format) or String (off, heat, cool, on, ...). `{ ga="thermostatMode" }`
 * (Mandatory) Temperature Ambient: Number. `{ ga="thermostatTemperatureAmbient" }`
 * (Mandatory) Temperature Setpoint: Number. `{ ga="thermostatTemperatureSetpoint" }`
-* (Optional) Humidity Setpoint High: Number. `{ ga="thermostatTemperatureSetpointHigh" }`
-* (Optional) Humidity Setpoint Low: Number. `{ ga="thermostatTemperatureSetpointLow" }`
+* (Optional) Temperature Setpoint High: Number. `{ ga="thermostatTemperatureSetpointHigh" }`
+* (Optional) Temperature Setpoint Low: Number. `{ ga="thermostatTemperatureSetpointLow" }`
 * (Optional) Humidity Ambient: Number. `{ ga="thermostatHumidityAmbient" }`
 
 If your thermostat does not have a mode, you should create one and manually assign a value (e.g. heat, cool, on, etc.) to have proper functionality.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -131,8 +131,8 @@ There must be at least three items as members of the group:
 * (Mandatory) Mode: Number (Zwave THERMOSTAT_MODE Format) or String (off, heat, cool, on, ...). `{ ga="thermostatMode" }`
 * (Mandatory) Temperature Ambient: Number. `{ ga="thermostatTemperatureAmbient" }`
 * (Mandatory) Temperature Setpoint: Number. `{ ga="thermostatTemperatureSetpoint" }`
-* (Optional) Humidity Setpoint High: Number. `{ ga="thermostatTemperatureSetpointHigh" }`
-* (Optional) Humidity Setpoint Low: Number. `{ ga="thermostatTemperatureSetpointLow" }`
+* (Optional) Temperature Setpoint High: Number. `{ ga="thermostatTemperatureSetpointHigh" }`
+* (Optional) Temperature Setpoint Low: Number. `{ ga="thermostatTemperatureSetpointLow" }`
 * (Optional) Humidity Ambient: Number. `{ ga="thermostatHumidityAmbient" }`
 
 If your thermostat does not have a mode, you should create one and manually assign a value (e.g. heat, cool, on, etc.) to have proper functionality.


### PR DESCRIPTION
Clarify usage of modes config option, fix wrong description of thermostatTemperatureSetpointHigh/Low items.

Related to #139.