### PR TITLE
Allow multiple types per device / Add Inverted for Switches

### DIFF
--- a/functions/commands.js
+++ b/functions/commands.js
@@ -155,8 +155,12 @@ class OnOffCommand extends GenericCommand {
     return ('on' in params) && typeof params.on === 'boolean';
   }
 
-  static convertParamsToValue(params) {
-    return params.on ? 'ON' : 'OFF';
+  static convertParamsToValue(params, item, device) {
+    let on = params.on;
+    if (device.customData && device.customData.inverted === true) {
+      on = !on;
+    }
+    return on ? 'ON' : 'OFF';
   }
 
   static getResponseStates(params) {

--- a/functions/devices.js
+++ b/functions/devices.js
@@ -79,15 +79,15 @@ class GenericDevice {
     };
   }
 
-  static get requiredItemType() {
-    return '';
+  static get requiredItemTypes() {
+    return [];
   }
 
   static checkItemType(item = {}) {
     return (
-      !this.requiredItemType ||
-      item.type === this.requiredItemType ||
-      (item.type === 'Group' && item.groupType && item.groupType === this.requiredItemType)
+      !this.requiredItemTypes.length ||
+      this.requiredItemTypes.includes(item.type) ||
+      (item.type === 'Group' && item.groupType && this.requiredItemTypes.includes(item.groupType))
     );
   }
 
@@ -109,8 +109,8 @@ class Switch extends GenericDevice {
     ];
   }
 
-  static get requiredItemType() {
-    return 'Switch';
+  static get requiredItemTypes() {
+    return ['Switch'];
   }
 
   static getState(item) {
@@ -175,8 +175,8 @@ class Valve extends GenericDevice {
     ];
   }
 
-  static get requiredItemType() {
-    return 'Switch';
+  static get requiredItemTypes() {
+    return ['Switch'];
   }
 
   static getState(item) {
@@ -195,8 +195,8 @@ class StartStopSwitch extends GenericDevice {
     ];
   }
 
-  static get requiredItemType() {
-    return 'Switch';
+  static get requiredItemTypes() {
+    return ['Switch'];
   }
 
   static getState(item) {
@@ -232,8 +232,8 @@ class Scene extends GenericDevice {
     ];
   }
 
-  static get requiredItemType() {
-    return 'Switch'
+  static get requiredItemTypes() {
+    return ['Switch'];
   }
 
   static getAttributes() {
@@ -256,8 +256,8 @@ class Lock extends GenericDevice {
     ];
   }
 
-  static get requiredItemType() {
-    return 'Switch';
+  static get requiredItemTypes() {
+    return ['Switch'];
   }
 
   static getState(item) {
@@ -280,8 +280,8 @@ class SecuritySystem extends GenericDevice {
     ];
   }
 
-  static get requiredItemType() {
-    return 'Switch';
+  static get requiredItemTypes() {
+    return ['Switch'];
   }
 
   static getState(item) {
@@ -313,8 +313,8 @@ class DimmableLight extends GenericDevice {
     ];
   }
 
-  static get requiredItemType() {
-    return 'Dimmer';
+  static get requiredItemTypes() {
+    return ['Dimmer'];
   }
 
   static getState(item) {
@@ -358,8 +358,8 @@ class ColorLight extends GenericDevice {
     return attributes;
   }
 
-  static get requiredItemType() {
-    return 'Color';
+  static get requiredItemTypes() {
+    return ['Color'];
   }
 
   static getState(item) {
@@ -394,13 +394,20 @@ class GenericOpenCloseDevice extends GenericDevice {
     return metadata;
   }
 
-  static get requiredItemType() {
-    return 'Rollershutter';
+  static get requiredItemTypes() {
+    return ['Rollershutter', 'Switch'];
   }
 
   static getState(item) {
+    let state = 0;
+    const itemType = item.type === 'Group' ? item.groupType : item.type;
+    if (itemType == 'Switch') {
+      state = item.state === 'ON' ? 0 : 100;
+    } else {
+      state = Number(item.state);
+    }
     return {
-      openPercent: getConfig(item).inverted === true ? Number(item.state) : 100 - Number(item.state)
+      openPercent: getConfig(item).inverted !== true ? 100 - state : state
     };
   }
 }
@@ -470,8 +477,8 @@ class Speaker extends GenericDevice {
     ];
   }
 
-  static get requiredItemType() {
-    return 'Dimmer';
+  static get requiredItemTypes() {
+    return ['Dimmer'];
   }
 
   static getState(item) {
@@ -502,8 +509,8 @@ class Camera extends GenericDevice {
     };
   }
 
-  static get requiredItemType() {
-    return 'String';
+  static get requiredItemTypes() {
+    return ['String'];
   }
 }
 
@@ -546,8 +553,8 @@ class Fan extends GenericDevice {
     return attributes;
   }
 
-  static get requiredItemType() {
-    return 'Dimmer';
+  static get requiredItemTypes() {
+    return ['Dimmer'];
   }
 
   static getState(item) {

--- a/functions/devices.js
+++ b/functions/devices.js
@@ -65,7 +65,7 @@ class GenericDevice {
       structureHint: config.structureHint,
       deviceInfo: {
         manufacturer: 'openHAB',
-        model: item.type,
+        model: item.label,
         hwVersion: '2.5.0',
         swVersion: '2.5.0'
       },
@@ -109,13 +109,23 @@ class Switch extends GenericDevice {
     ];
   }
 
+  static getMetadata(item) {
+    const metadata = super.getMetadata(item);
+    metadata.customData.inverted = getConfig(item).inverted === true;
+    return metadata;
+  }
+
   static get requiredItemTypes() {
     return ['Switch'];
   }
 
   static getState(item) {
+    let state = item.state === 'ON';
+    if (getConfig(item).inverted === true) {
+      state = !state;
+    }
     return {
-      on: item.state === 'ON'
+      on: state
     };
   }
 }

--- a/tests/__snapshots__/openhab.metadata.test.js.snap
+++ b/tests/__snapshots__/openhab.metadata.test.js.snap
@@ -56,7 +56,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "Dimmer",
+        "model": "My Fan",
         "swVersion": "2.5.0",
       },
       "id": "MyFan",
@@ -89,6 +89,7 @@ Object {
       "attributes": Object {},
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
+        "inverted": false,
         "itemType": "Switch",
         "tfaAck": undefined,
         "tfaPin": undefined,
@@ -96,7 +97,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "Switch",
+        "model": "SwitchLight",
         "swVersion": "2.5.0",
       },
       "id": "MySwitch",
@@ -130,7 +131,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "Dimmer",
+        "model": "DimmLight",
         "swVersion": "2.5.0",
       },
       "id": "MyDimmer",
@@ -165,7 +166,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "Color",
+        "model": "ColorLight",
         "swVersion": "2.5.0",
       },
       "id": "MyLight",
@@ -192,6 +193,7 @@ Object {
       "attributes": Object {},
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
+        "inverted": false,
         "itemType": "Switch",
         "tfaAck": undefined,
         "tfaPin": undefined,
@@ -199,7 +201,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "Group",
+        "model": "GroupLight",
         "swVersion": "2.5.0",
       },
       "id": "MyLightGroup",
@@ -231,7 +233,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "Group",
+        "model": "GroupDimmer",
         "swVersion": "2.5.0",
       },
       "id": "MyDimmerGroup",
@@ -266,7 +268,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "Group",
+        "model": "GroupColor",
         "swVersion": "2.5.0",
       },
       "id": "MyColorGroup",
@@ -309,7 +311,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "Switch",
+        "model": "My Scene",
         "swVersion": "2.5.0",
       },
       "id": "MyScene",

--- a/tests/__snapshots__/openhab.tags.test.js.snap
+++ b/tests/__snapshots__/openhab.tags.test.js.snap
@@ -7,6 +7,7 @@ Object {
       "attributes": Object {},
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
+        "inverted": false,
         "itemType": "Switch",
         "tfaAck": undefined,
         "tfaPin": undefined,
@@ -14,7 +15,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "Switch",
+        "model": "SwitchLight",
         "swVersion": "2.5.0",
       },
       "id": "MySwitch",
@@ -46,7 +47,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "Dimmer",
+        "model": "DimmLight",
         "swVersion": "2.5.0",
       },
       "id": "MyDimmer",
@@ -81,7 +82,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "Color",
+        "model": "ColorLight",
         "swVersion": "2.5.0",
       },
       "id": "MyLight",
@@ -108,6 +109,7 @@ Object {
       "attributes": Object {},
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
+        "inverted": false,
         "itemType": "Switch",
         "tfaAck": undefined,
         "tfaPin": undefined,
@@ -115,7 +117,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "Group",
+        "model": "GroupLight",
         "swVersion": "2.5.0",
       },
       "id": "MyLightGroup",
@@ -147,7 +149,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "Group",
+        "model": "GroupDimmer",
         "swVersion": "2.5.0",
       },
       "id": "MyDimmerGroup",
@@ -182,7 +184,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "Group",
+        "model": "GroupColor",
         "swVersion": "2.5.0",
       },
       "id": "MyColorGroup",

--- a/tests/devices.metadata.test.js
+++ b/tests/devices.metadata.test.js
@@ -18,6 +18,26 @@ describe('Test Switch Devices with Metadata', () => {
     });
   });
 
+  test('Inverted Switch Type', () => {
+    const item = {
+      type: 'Switch',
+      state: 'ON',
+      metadata: {
+        ga: {
+          value: 'Switch',
+          config: {
+            inverted: true
+          }
+        }
+      }
+    };
+    const device = Devices.getDeviceForItem(item);
+    expect(device.name).toBe('Switch');
+    expect(device.getState(item)).toStrictEqual({
+      on: false
+    });
+  });
+
   test('Valve Switch Type', () => {
     const item = {
       type: 'Switch',
@@ -464,7 +484,7 @@ describe('Test Thermostat Device with Metadata', () => {
         },
         "customData": {
           "deviceType": "action.devices.types.THERMOSTAT",
-          "itemType": "Group",
+          "itemType": undefined,
           "tfaAck": undefined,
           "tfaPin": undefined
         },
@@ -473,7 +493,7 @@ describe('Test Thermostat Device with Metadata', () => {
         "deviceInfo": {
           "hwVersion": "2.5.0",
           "manufacturer": "openHAB",
-          "model": "Group",
+          "model": "MyThermostat",
           "swVersion": "2.5.0",
         },
         "id": "MyItem",

--- a/tests/openhab.metadata.test.js
+++ b/tests/openhab.metadata.test.js
@@ -250,6 +250,114 @@ describe('Test QUERY with Metadata', () => {
     });
   });
 
+  test('Blinds as Rollershutter Device', async () => {
+    const item =
+    {
+      "state": "20",
+      "type": "Rollershutter",
+      "name": "MyBlinds",
+      "metadata": {
+        "ga": {
+          "value": "Blinds"
+        }
+      }
+    };
+
+    const getItemMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve(item));
+
+    const apiHandler = {
+      getItem: getItemMock
+    };
+
+    const payload = await new OpenHAB(apiHandler).handleQuery([{
+      "id": "MyBlinds"
+    }]);
+
+    expect(getItemMock).toHaveBeenCalledTimes(1);
+    expect(payload).toStrictEqual({
+      "devices": {
+        "MyBlinds": {
+          "openPercent": 80,
+          "online": true,
+        },
+      },
+    });
+  });
+
+  test('Inverted Blinds as Rollershutter Device', async () => {
+    const item =
+    {
+      "state": "20",
+      "type": "Rollershutter",
+      "name": "MyBlinds",
+      "metadata": {
+        "ga": {
+          "value": "Blinds",
+          "config": {
+            "inverted": true
+          }
+        }
+      }
+    };
+
+    const getItemMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve(item));
+
+    const apiHandler = {
+      getItem: getItemMock
+    };
+
+    const payload = await new OpenHAB(apiHandler).handleQuery([{
+      "id": "MyBlinds"
+    }]);
+
+    expect(getItemMock).toHaveBeenCalledTimes(1);
+    expect(payload).toStrictEqual({
+      "devices": {
+        "MyBlinds": {
+          "openPercent": 20,
+          "online": true,
+        },
+      },
+    });
+  });
+
+  test('Blinds as Switch Device', async () => {
+    const item =
+    {
+      "state": "OFF",
+      "type": "Switch",
+      "name": "MyBlinds",
+      "metadata": {
+        "ga": {
+          "value": "Blinds"
+        }
+      }
+    };
+
+    const getItemMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve(item));
+
+    const apiHandler = {
+      getItem: getItemMock
+    };
+
+    const payload = await new OpenHAB(apiHandler).handleQuery([{
+      "id": "MyBlinds"
+    }]);
+
+    expect(getItemMock).toHaveBeenCalledTimes(1);
+    expect(payload).toStrictEqual({
+      "devices": {
+        "MyBlinds": {
+          "openPercent": 0,
+          "online": true,
+        },
+      },
+    });
+  });
+
   test('Fan Device', async () => {
     const item = {
       "state": "50",


### PR DESCRIPTION
As requested in #149 we hereby allow multiple types per device.
Thus, in addition to `Rollershutter` also `Switch` item types can be used on `OpenClose` devices like `Door` or `Blinds`.
The `OpenClose` devices are currently the only ones allowing multiple types.
Additionally, `Switch` devices types can now also configured using the `inverted` config option in the metadata.