### PR TITLE
Add support for inverted option for more devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Number HK_Basement_Humid "Basement Humidity" (g_HK_Basement_TSTAT) { ga="thermos
 Currently the following metadata values are supported (also depending on Googles API capabilities):
 
 * `Switch / Dimmer / Color { ga="Light" }`
-* `Switch { ga="Switch" }`
+* `Switch { ga="Switch" [ inverted=true ] }` (all Switch items can use the inverted option)
 * `Switch { ga="Outlet" }`
 * `Switch { ga="CoffeeMaker" }`
 * `Switch { ga="WaterHeater" }`
@@ -223,12 +223,14 @@ Currently the following metadata values are supported (also depending on Googles
 * `Rollershutter { ga="Pergola" }`
 * `Rollershutter { ga="Shutter" }`
 * `Rollershutter { ga="Window" }`
-* `Group { ga="Thermostat" }`
+* `Group { ga="Thermostat" [ modes="..." ] }`
 * `Number { ga="thermostatTemperatureAmbient" }` as part of Thermostat group
 * `Number { ga="thermostatHumidityAmbient" }` as part of Thermostat group
 * `Number { ga="thermostatTemperatureSetpoint" }` as part of Thermostat group
 * `Number / String { ga="thermostatMode" }` as part of Thermostat group
 * `String { ga="Camera" [ protocols="hls,dash" ] }`
+
+_\* All Rollershutter devices can also be used with a Switch item with the limitation of only supporting open and close states._
 
 Item labels are not mandatory in openHAB, but for the Google Assistant Action they are absolutely necessary!
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -27,7 +27,7 @@ In openHAB 2 items are exposed via [metadata](https://www.openhab.org/docs/confi
 Currently the following metadata values are supported (also depending on Googles API capabilities):
 
 * `Switch / Dimmer / Color { ga="Light" }`
-* `Switch { ga="Switch" }`
+* `Switch { ga="Switch" [ inverted=true ] }` (all Switch items can use the inverted option)
 * `Switch { ga="Outlet" }`
 * `Switch { ga="CoffeeMaker" }`
 * `Switch { ga="WaterHeater" }`
@@ -51,12 +51,14 @@ Currently the following metadata values are supported (also depending on Googles
 * `Rollershutter { ga="Pergola" }`
 * `Rollershutter { ga="Shutter" }`
 * `Rollershutter { ga="Window" }`
-* `Group { ga="Thermostat" }`
+* `Group { ga="Thermostat" [ modes="..." ] }`
 * `Number { ga="thermostatTemperatureAmbient" }` as part of Thermostat group
 * `Number { ga="thermostatHumidityAmbient" }` as part of Thermostat group
 * `Number { ga="thermostatTemperatureSetpoint" }` as part of Thermostat group
 * `Number / String { ga="thermostatMode" }` as part of Thermostat group
 * `String { ga="Camera" [ protocols="hls,dash" ] }`
+
+_\* All Rollershutter devices can also be used with a Switch item with the limitation of only supporting open and close states._
 
 Example item configuration:
   ```

--- a/functions/commands.js
+++ b/functions/commands.js
@@ -179,8 +179,12 @@ class LockUnlockCommand extends GenericCommand {
     return ('lock' in params) && typeof params.lock === 'boolean';
   }
 
-  static convertParamsToValue(params) {
-    return params.lock ? 'ON' : 'OFF';
+  static convertParamsToValue(params, item, device) {
+    let lock = params.lock;
+    if (device.customData && device.customData.inverted === true) {
+      lock = !lock;
+    }
+    return lock ? 'ON' : 'OFF';
   }
 
   static getResponseStates(params) {
@@ -199,8 +203,12 @@ class ArmDisarmCommand extends GenericCommand {
     return ('arm' in params) && typeof params.arm === 'boolean';
   }
 
-  static convertParamsToValue(params) {
-    return params.arm ? 'ON' : 'OFF';
+  static convertParamsToValue(params, item, device) {
+    let arm = params.arm;
+    if (device.customData && device.customData.inverted === true) {
+      arm = !arm;
+    }
+    return arm ? 'ON' : 'OFF';
   }
 
   static getResponseStates(params) {
@@ -219,8 +227,12 @@ class ActivateSceneCommand extends GenericCommand {
     return (('deactivate' in params) && typeof params.deactivate === 'boolean') || !('deactivate' in params);
   }
 
-  static convertParamsToValue(params) {
-    return !params.deactivate ? 'ON' : 'OFF';
+  static convertParamsToValue(params, item, device) {
+    let deactivate = params.deactivate;
+    if (device.customData && device.customData.inverted === true) {
+      deactivate = !deactivate;
+    }
+    return !deactivate ? 'ON' : 'OFF';
   }
 }
 

--- a/functions/devices.js
+++ b/functions/devices.js
@@ -73,6 +73,7 @@ class GenericDevice {
       customData: {
         itemType: item.type === 'Group' ? item.groupType : item.type,
         deviceType: this.type,
+        inverted: config.inverted === true,
         tfaAck: config.tfaAck,
         tfaPin: config.tfaPin
       }
@@ -107,12 +108,6 @@ class Switch extends GenericDevice {
     return [
       'action.devices.traits.OnOff'
     ];
-  }
-
-  static getMetadata(item) {
-    const metadata = super.getMetadata(item);
-    metadata.customData.inverted = getConfig(item).inverted === true;
-    return metadata;
   }
 
   static get requiredItemTypes() {
@@ -190,8 +185,12 @@ class Valve extends GenericDevice {
   }
 
   static getState(item) {
+    let state = item.state === 'ON';
+    if (getConfig(item).inverted === true) {
+      state = !state;
+    }
     return {
-      openPercent: item.state === 'ON' ? 100 : 0
+      openPercent: state ? 100 : 0
     };
   }
 }
@@ -210,9 +209,13 @@ class StartStopSwitch extends GenericDevice {
   }
 
   static getState(item) {
+    let state = item.state === 'ON';
+    if (getConfig(item).inverted === true) {
+      state = !state;
+    }
     return {
-      isRunning: item.state === 'ON',
-      isPaused: item.state !== 'ON'
+      isRunning: state,
+      isPaused: !state
     };
   }
 }
@@ -271,8 +274,12 @@ class Lock extends GenericDevice {
   }
 
   static getState(item) {
+    let state = item.state === 'ON';
+    if (getConfig(item).inverted === true) {
+      state = !state;
+    }
     return {
-      isLocked: item.state === 'ON'
+      isLocked: state
     };
   }
 }
@@ -295,8 +302,12 @@ class SecuritySystem extends GenericDevice {
   }
 
   static getState(item) {
+    let state = item.state === 'ON';
+    if (getConfig(item).inverted === true) {
+      state = !state;
+    }
     return {
-      isArmed: item.state === 'ON'
+      isArmed: state
     };
   }
 }
@@ -396,12 +407,6 @@ class GenericOpenCloseDevice extends GenericDevice {
       'action.devices.traits.OpenClose',
       'action.devices.traits.StartStop'
     ];
-  }
-
-  static getMetadata(item) {
-    const metadata = super.getMetadata(item);
-    metadata.customData.inverted = getConfig(item).inverted === true;
-    return metadata;
   }
 
   static get requiredItemTypes() {

--- a/tests/__snapshots__/openhab.metadata.test.js.snap
+++ b/tests/__snapshots__/openhab.metadata.test.js.snap
@@ -49,6 +49,7 @@ Object {
       },
       "customData": Object {
         "deviceType": "action.devices.types.FAN",
+        "inverted": false,
         "itemType": "Dimmer",
         "tfaAck": undefined,
         "tfaPin": undefined,
@@ -124,6 +125,7 @@ Object {
       "attributes": Object {},
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
+        "inverted": false,
         "itemType": "Dimmer",
         "tfaAck": undefined,
         "tfaPin": undefined,
@@ -159,6 +161,7 @@ Object {
       },
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
+        "inverted": false,
         "itemType": "Color",
         "tfaAck": undefined,
         "tfaPin": undefined,
@@ -226,6 +229,7 @@ Object {
       "attributes": Object {},
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
+        "inverted": false,
         "itemType": "Dimmer",
         "tfaAck": undefined,
         "tfaPin": undefined,
@@ -261,6 +265,7 @@ Object {
       },
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
+        "inverted": false,
         "itemType": "Color",
         "tfaAck": undefined,
         "tfaPin": undefined,
@@ -304,6 +309,7 @@ Object {
       },
       "customData": Object {
         "deviceType": "action.devices.types.SCENE",
+        "inverted": false,
         "itemType": "Switch",
         "tfaAck": undefined,
         "tfaPin": undefined,

--- a/tests/__snapshots__/openhab.tags.test.js.snap
+++ b/tests/__snapshots__/openhab.tags.test.js.snap
@@ -40,6 +40,7 @@ Object {
       "attributes": Object {},
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
+        "inverted": false,
         "itemType": "Dimmer",
         "tfaAck": undefined,
         "tfaPin": undefined,
@@ -75,6 +76,7 @@ Object {
       },
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
+        "inverted": false,
         "itemType": "Color",
         "tfaAck": undefined,
         "tfaPin": undefined,
@@ -142,6 +144,7 @@ Object {
       "attributes": Object {},
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
+        "inverted": false,
         "itemType": "Dimmer",
         "tfaAck": undefined,
         "tfaPin": undefined,
@@ -177,6 +180,7 @@ Object {
       },
       "customData": Object {
         "deviceType": "action.devices.types.LIGHT",
+        "inverted": false,
         "itemType": "Color",
         "tfaAck": undefined,
         "tfaPin": undefined,

--- a/tests/devices.metadata.test.js
+++ b/tests/devices.metadata.test.js
@@ -485,6 +485,7 @@ describe('Test Thermostat Device with Metadata', () => {
         "customData": {
           "deviceType": "action.devices.types.THERMOSTAT",
           "itemType": undefined,
+          "inverted": false,
           "tfaAck": undefined,
           "tfaPin": undefined
         },

--- a/tests/openhab.metadata.test.js
+++ b/tests/openhab.metadata.test.js
@@ -1091,7 +1091,7 @@ describe('Test EXECUTE with Metadata', () => {
       "execution": [{
         "command": "action.devices.commands.LockUnlock",
         "params": {
-          lock: true
+          "lock": true
         }
       }]
     }];
@@ -1099,6 +1099,7 @@ describe('Test EXECUTE with Metadata', () => {
     const payload = await new OpenHAB(apiHandler).handleExecute(commands);
 
     expect(getItemMock).toHaveBeenCalledTimes(1);
+    expect(sendCommandMock).toHaveBeenCalledTimes(0);
     expect(payload).toStrictEqual({
       "commands": [{
         "ids": [
@@ -1138,7 +1139,7 @@ describe('Test EXECUTE with Metadata', () => {
       "execution": [{
         "command": "action.devices.commands.LockUnlock",
         "params": {
-          lock: true
+          "lock": true
         },
         "challenge": {
           "ack": true
@@ -1149,6 +1150,51 @@ describe('Test EXECUTE with Metadata', () => {
     const payload = await new OpenHAB(apiHandler).handleExecute(commands);
 
     expect(getItemMock).toHaveBeenCalledTimes(0);
+    expect(sendCommandMock).toBeCalledWith('MyLock', 'ON');
+    expect(payload).toStrictEqual({
+      "commands": [{
+        "ids": [
+          "MyLock"
+        ],
+        "states": {
+          "online": true,
+          "isLocked": true
+        },
+        "status": "SUCCESS"
+      }]
+    });
+  });
+
+  test('Lock inverted', async () => {
+    const getItemMock = jest.fn();
+    const sendCommandMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve());
+    sendCommandMock.mockReturnValue(Promise.resolve());
+
+    const apiHandler = {
+      getItem: getItemMock,
+      sendCommand: sendCommandMock
+    };
+
+    const commands = [{
+      "devices": [{
+        "customData": {
+          "inverted": true
+        },
+        "id": "MyLock"
+      }],
+      "execution": [{
+        "command": "action.devices.commands.LockUnlock",
+        "params": {
+          lock: true
+        }
+      }]
+    }];
+
+    const payload = await new OpenHAB(apiHandler).handleExecute(commands);
+
+    expect(getItemMock).toHaveBeenCalledTimes(0);
+    expect(sendCommandMock).toBeCalledWith('MyLock', 'OFF');
     expect(payload).toStrictEqual({
       "commands": [{
         "ids": [


### PR DESCRIPTION
With this PR the `inverted` option is available for more devices using Switch items (Lock, SecuritySystem, Scene, Valve, "Start-Stop-Devices").

Furthermore, the documentation is adjusted to reflect more usage options.

Follow up to: https://github.com/openhab/openhab-google-assistant/issues/149