### PR TITLE
Fix wrong metadata label for coffee maker

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Currently the following metadata values are supported (also depending on Googles
 * `Switch / Dimmer / Color { ga="Light" }`
 * `Switch { ga="Switch" }`
 * `Switch { ga="Outlet" }`
-* `Switch { ga="CoffeeMaker" }`
+* `Switch { ga="Coffee_Maker" }`
 * `Switch { ga="WaterHeater" }`
 * `Switch { ga="Fireplace" }`
 * `Switch { ga="Valve" }`

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -29,7 +29,7 @@ Currently the following metadata values are supported (also depending on Googles
 * `Switch / Dimmer / Color { ga="Light" }`
 * `Switch { ga="Switch" }`
 * `Switch { ga="Outlet" }`
-* `Switch { ga="CoffeeMaker" }`
+* `Switch { ga="Coffee_Maker" }`
 * `Switch { ga="WaterHeater" }`
 * `Switch { ga="Fireplace" }`
 * `Switch { ga="Valve" }`


### PR DESCRIPTION
With this PR the incorrect documentation for Coffee Maker devices is fixed.

Resolves https://github.com/openhab/openhab-google-assistant/issues/154