### PR TITLE
Add support for Contact items for Locks and OpenClose devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Currently the following metadata values are supported (also depending on Googles
 * `Switch { ga="Sprinkler" }`
 * `Switch { ga="Vacuum" }`
 * `Switch { ga="Scene" }`
-* `Switch { ga="Lock" [ tfaAck=true ] }`
+* `Switch / Contact { ga="Lock" [ tfaAck=true ] }`
 * `Switch { ga="SecuritySystem" [ tfaPin="1234" ] }`
 * `Dimmer { ga="Speaker" }`
 * `Switch / Dimmer { ga="Fan" [ speeds="0=away:zero,50=default:standard:one,100=high:two", lang="en", ordered=true ] }` (for Dimmer the options have to be set)
@@ -230,7 +230,7 @@ Currently the following metadata values are supported (also depending on Googles
 * `Number / String { ga="thermostatMode" }` as part of Thermostat group
 * `String { ga="Camera" [ protocols="hls,dash" ] }`
 
-_\* All Rollershutter devices can also be used with a Switch item with the limitation of only supporting open and close states._
+_\* All Rollershutter devices can also be used with a Switch or Contact item with the limitation of only supporting open and close states._
 
 Item labels are not mandatory in openHAB, but for the Google Assistant Action they are absolutely necessary!
 
@@ -242,6 +242,11 @@ Furthermore, you can state synonyms for the device name: `Switch KitchenLight "K
 
 To ease setting up new devices you can add a room hint: `[ roomHint="Living Room" ]`.
 
+For devices supporting the OpenClose trait, the attributes `[ discreteOnlyOpenClose=false, queryOnlyOpenClose=false ]` can be configured.
+- discreteOnlyOpenClose defaults to false. When set to true, this indicates that the device must either be fully open or fully closed (that is, it does not support values between 0% and 100%). An example of such a device may be a valve.
+- queryOnlyOpenClose defaults to false. Is set to true for `Contact` items. Indicates if the device can only be queried for state information and cannot be controlled. Sensors that can only report open state should set this field to true.
+
+---
 
 NOTE: metadata is not (yet?) available via paperUI. Either you create your items via ".items" files, or you can:
 - add metadata via console:
@@ -318,6 +323,11 @@ The option _ordered_ will tell the system that your list is ordered and you will
 Blinds should always use the `Rollershutter` item type.
 Since Google and openHAB use the oposite percentage value for "opened" or "closed", the action will tranlate this automatically.
 If the values are still inverted in your case, you can state the `[ inverted=true ]` option for all `Rollershutter` items.
+
+Since Google only tells the open percentage (and not the verb "close" or "down"), it can not be differentiated between saying "set blind to 100%" or "open blind".
+Therefore, it is not possible to "not invert" the verbs, if the user chooses to invert the numbers.
+
+---
 
 More details about the setup and the service linkage (https://myopenhab.org) procedure within the Google App can be found in the [USAGE documentation](docs/USAGE.md).
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -36,7 +36,7 @@ Currently the following metadata values are supported (also depending on Googles
 * `Switch { ga="Sprinkler" }`
 * `Switch { ga="Vacuum" }`
 * `Switch { ga="Scene" }`
-* `Switch { ga="Lock" [ tfaAck=true ] }`
+* `Switch / Contact { ga="Lock" [ tfaAck=true ] }`
 * `Switch { ga="SecuritySystem" [ tfaPin="1234" ] }`
 * `Dimmer { ga="Speaker" }`
 * `Switch / Dimmer { ga="Fan" [ speeds="0=away:zero,50=default:standard:one,100=high:two", lang="en", ordered=true ] }` (for Dimmer the options have to be set)
@@ -58,7 +58,7 @@ Currently the following metadata values are supported (also depending on Googles
 * `Number / String { ga="thermostatMode" }` as part of Thermostat group
 * `String { ga="Camera" [ protocols="hls,dash" ] }`
 
-_\* All Rollershutter devices can also be used with a Switch item with the limitation of only supporting open and close states._
+_\* All Rollershutter devices can also be used with a Switch or Contact item with the limitation of only supporting open and close states._
 
 Example item configuration:
   ```
@@ -87,6 +87,11 @@ Furthermore, you can state synonyms for the device name: `Switch KitchenLight "K
 
 To ease setting up new devices you can add a room hint: `[ roomHint="Living Room" ]`.
 
+For devices supporting the OpenClose trait, the attributes `[ discreteOnlyOpenClose=false, queryOnlyOpenClose=false ]` can be configured.
+- discreteOnlyOpenClose defaults to false. When set to true, this indicates that the device must either be fully open or fully closed (that is, it does not support values between 0% and 100%). An example of such a device may be a valve.
+- queryOnlyOpenClose defaults to false. Is set to true for `Contact` items. Indicates if the device can only be queried for state information and cannot be controlled. Sensors that can only report open state should set this field to true.
+
+---
 
 NOTE: metadata is not (yet?) available via paperUI. Either you create your items via ".items" files, or you can:
 - add metadata via console:
@@ -163,6 +168,9 @@ The option _ordered_ will tell the system that your list is ordered and you will
 Blinds should always use the `Rollershutter` item type.
 Since Google and openHAB use the oposite percentage value for "opened" or "closed", the action will tranlate this automatically.
 If the values are still inverted in your case, you can state the `[ inverted=true ]` option for all `Rollershutter` items.
+
+Since Google only tells the open percentage (and not the verb "close" or "down"), it can not be differentiated between saying "set blind to 100%" or "open blind".
+Therefore, it is not possible to "not invert" the verbs, if the user chooses to invert the numbers.
 
 
 ## Setup & Usage on Google Assistant App

--- a/functions/commands.js
+++ b/functions/commands.js
@@ -180,6 +180,9 @@ class LockUnlockCommand extends GenericCommand {
   }
 
   static convertParamsToValue(params, item, device) {
+    if (device.customData && device.customData.itemType === 'Contact') {
+      throw { statusCode: 400 };
+    }
     let lock = params.lock;
     if (device.customData && device.customData.inverted === true) {
       lock = !lock;
@@ -393,6 +396,9 @@ class OpenCloseCommand extends GenericCommand {
   }
 
   static convertParamsToValue(params, item, device) {
+    if (device.customData && device.customData.itemType === 'Contact') {
+      throw { statusCode: 400 };
+    }
     let openPercent = params.openPercent;
     if (device.customData && device.customData.inverted === true) {
       openPercent = 100 - openPercent;
@@ -422,6 +428,9 @@ class StartStopCommand extends GenericCommand {
   }
 
   static convertParamsToValue(params, item, device) {
+    if (device.customData && device.customData.itemType === 'Contact') {
+      throw { statusCode: 400 };
+    }
     let value = params.start ? 'MOVE' : 'STOP';
     // item can not handle StartStop --> we will send "ON" / "OFF"
     if (device.customData && device.customData.itemType !== 'Rollershutter') {

--- a/functions/devices.js
+++ b/functions/devices.js
@@ -415,6 +415,9 @@ class GenericOpenCloseDevice extends GenericDevice {
     attributes.discreteOnlyOpenClose = getConfig(item).discreteOnlyOpenClose === true;
     attributes.queryOnlyOpenClose = getConfig(item).queryOnlyOpenClose === true;
     const itemType = item.type === 'Group' && item.groupType ? item.groupType : item.type;
+    if (itemType === 'Switch') {
+      attributes.discreteOnlyOpenClose = true;
+    }
     if (itemType === 'Contact') {
       attributes.discreteOnlyOpenClose = true;
       attributes.queryOnlyOpenClose = true;

--- a/functions/devices.js
+++ b/functions/devices.js
@@ -410,6 +410,18 @@ class GenericOpenCloseDevice extends GenericDevice {
     ];
   }
 
+  static getAttributes(item) {
+    const attributes = {};
+    attributes.discreteOnlyOpenClose = getConfig(item).discreteOnlyOpenClose === true;
+    attributes.queryOnlyOpenClose = getConfig(item).queryOnlyOpenClose === true;
+    const itemType = item.type === 'Group' && item.groupType ? item.groupType : item.type;
+    if (itemType === 'Contact') {
+      attributes.discreteOnlyOpenClose = true;
+      attributes.queryOnlyOpenClose = true;
+    }
+    return attributes;
+  }
+
   static get requiredItemTypes() {
     return ['Rollershutter', 'Switch', 'Contact'];
   }

--- a/tests/__snapshots__/openhab.metadata.test.js.snap
+++ b/tests/__snapshots__/openhab.metadata.test.js.snap
@@ -57,7 +57,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "My Fan",
+        "model": "Dimmer:MyFan",
         "swVersion": "2.5.0",
       },
       "id": "MyFan",
@@ -98,7 +98,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "SwitchLight",
+        "model": "Switch:MySwitch",
         "swVersion": "2.5.0",
       },
       "id": "MySwitch",
@@ -133,7 +133,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "DimmLight",
+        "model": "Dimmer:MyDimmer",
         "swVersion": "2.5.0",
       },
       "id": "MyDimmer",
@@ -169,7 +169,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "ColorLight",
+        "model": "Color:MyLight",
         "swVersion": "2.5.0",
       },
       "id": "MyLight",
@@ -204,7 +204,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "GroupLight",
+        "model": "Switch:MyLightGroup",
         "swVersion": "2.5.0",
       },
       "id": "MyLightGroup",
@@ -237,7 +237,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "GroupDimmer",
+        "model": "Dimmer:MyDimmerGroup",
         "swVersion": "2.5.0",
       },
       "id": "MyDimmerGroup",
@@ -273,7 +273,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "GroupColor",
+        "model": "Color:MyColorGroup",
         "swVersion": "2.5.0",
       },
       "id": "MyColorGroup",
@@ -317,7 +317,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "My Scene",
+        "model": "Switch:MyScene",
         "swVersion": "2.5.0",
       },
       "id": "MyScene",

--- a/tests/__snapshots__/openhab.metadata.test.js.snap
+++ b/tests/__snapshots__/openhab.metadata.test.js.snap
@@ -352,14 +352,15 @@ Object {
       },
       "customData": Object {
         "deviceType": "action.devices.types.THERMOSTAT",
-        "itemType": undefined,
+        "inverted": false,
+        "itemType": "Group",
         "tfaAck": undefined,
         "tfaPin": undefined,
       },
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "My Thermostat",
+        "model": "Group:MyThermostat",
         "swVersion": "2.5.0",
       },
       "id": "MyThermostat",

--- a/tests/__snapshots__/openhab.tags.test.js.snap
+++ b/tests/__snapshots__/openhab.tags.test.js.snap
@@ -15,7 +15,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "SwitchLight",
+        "model": "Switch:MySwitch",
         "swVersion": "2.5.0",
       },
       "id": "MySwitch",
@@ -48,7 +48,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "DimmLight",
+        "model": "Dimmer:MyDimmer",
         "swVersion": "2.5.0",
       },
       "id": "MyDimmer",
@@ -84,7 +84,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "ColorLight",
+        "model": "Color:MyLight",
         "swVersion": "2.5.0",
       },
       "id": "MyLight",
@@ -119,7 +119,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "GroupLight",
+        "model": "Switch:MyLightGroup",
         "swVersion": "2.5.0",
       },
       "id": "MyLightGroup",
@@ -152,7 +152,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "GroupDimmer",
+        "model": "Dimmer:MyDimmerGroup",
         "swVersion": "2.5.0",
       },
       "id": "MyDimmerGroup",
@@ -188,7 +188,7 @@ Object {
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "GroupColor",
+        "model": "Color:MyColorGroup",
         "swVersion": "2.5.0",
       },
       "id": "MyColorGroup",

--- a/tests/devices.metadata.test.js
+++ b/tests/devices.metadata.test.js
@@ -518,8 +518,8 @@ describe('Test Thermostat Device with Metadata', () => {
         },
         "customData": {
           "deviceType": "action.devices.types.THERMOSTAT",
-          "itemType": undefined,
           "inverted": false,
+          "itemType": "Group",
           "tfaAck": undefined,
           "tfaPin": undefined
         },
@@ -528,7 +528,7 @@ describe('Test Thermostat Device with Metadata', () => {
         "deviceInfo": {
           "hwVersion": "2.5.0",
           "manufacturer": "openHAB",
-          "model": "MyThermostat",
+          "model": "Group:MyItem",
           "swVersion": "2.5.0",
         },
         "id": "MyItem",

--- a/tests/devices.metadata.test.js
+++ b/tests/devices.metadata.test.js
@@ -198,7 +198,7 @@ describe('Test Light Devices with Metadata', () => {
   });
 });
 
-describe('Test Rollershutter Devices with Metadata', () => {
+describe('Test OpenClose Devices', () => {
   test('Invalid Blinds Type', () => {
     expect(Devices.getDeviceForItem({
       type: 'Dimmer',
@@ -222,6 +222,10 @@ describe('Test Rollershutter Devices with Metadata', () => {
     };
     const device = Devices.getDeviceForItem(item);
     expect(device.name).toBe('Blinds');
+    expect(device.getAttributes(item)).toStrictEqual({
+      discreteOnlyOpenClose: false,
+      queryOnlyOpenClose: false
+    });
     expect(device.getState(item)).toStrictEqual({
       openPercent: 100
     });
@@ -235,15 +239,41 @@ describe('Test Rollershutter Devices with Metadata', () => {
         ga: {
           value: 'BLINDS',
           config: {
-            inverted: true
+            inverted: true,
+            discreteOnlyOpenClose: true
           }
         }
       }
     };
     const device = Devices.getDeviceForItem(item);
     expect(device.name).toBe('Blinds');
+    expect(device.getAttributes(item)).toStrictEqual({
+      discreteOnlyOpenClose: true,
+      queryOnlyOpenClose: false
+    });
     expect(device.getState(item)).toStrictEqual({
       openPercent: 0
+    });
+  });
+
+  test('Window as Contact', () => {
+    const item = {
+      type: 'Contact',
+      state: 'OPEN',
+      metadata: {
+        ga: {
+          value: 'WINDOW'
+        }
+      }
+    };
+    const device = Devices.getDeviceForItem(item);
+    expect(device.name).toBe('Window');
+    expect(device.getAttributes(item)).toStrictEqual({
+      discreteOnlyOpenClose: true,
+      queryOnlyOpenClose: true
+    });
+    expect(device.getState(item)).toStrictEqual({
+      openPercent: 100
     });
   });
 });

--- a/tests/openhab.metadata.test.js
+++ b/tests/openhab.metadata.test.js
@@ -321,6 +321,41 @@ describe('Test QUERY with Metadata', () => {
     });
   });
 
+  test('Lock Device as Contact', async () => {
+    const item =
+    {
+      "state": "CLOSED",
+      "type": "Contact",
+      "name": "MyLock",
+      "metadata": {
+        "ga": {
+          "value": "Lock"
+        }
+      }
+    };
+
+    const getItemMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve(item));
+
+    const apiHandler = {
+      getItem: getItemMock
+    };
+
+    const payload = await new OpenHAB(apiHandler).handleQuery([{
+      "id": "MyLock"
+    }]);
+
+    expect(getItemMock).toHaveBeenCalledTimes(1);
+    expect(payload).toStrictEqual({
+      "devices": {
+        "MyLock": {
+          "isLocked": true,
+          "online": true,
+        },
+      },
+    });
+  });
+
   test('Multiple Light Devices', async () => {
     const item1 =
     {
@@ -477,6 +512,41 @@ describe('Test QUERY with Metadata', () => {
     expect(payload).toStrictEqual({
       "devices": {
         "MyBlinds": {
+          "openPercent": 0,
+          "online": true,
+        },
+      },
+    });
+  });
+
+  test('Window as Contact', async () => {
+    const item =
+    {
+      "state": "CLOSED",
+      "type": "Contact",
+      "name": "MyWindow",
+      "metadata": {
+        "ga": {
+          "value": "Window"
+        }
+      }
+    };
+
+    const getItemMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve(item));
+
+    const apiHandler = {
+      getItem: getItemMock
+    };
+
+    const payload = await new OpenHAB(apiHandler).handleQuery([{
+      "id": "MyWindow"
+    }]);
+
+    expect(getItemMock).toHaveBeenCalledTimes(1);
+    expect(payload).toStrictEqual({
+      "devices": {
+        "MyWindow": {
           "openPercent": 0,
           "online": true,
         },
@@ -1141,7 +1211,7 @@ describe('Test EXECUTE with Metadata', () => {
     });
   });
 
-  test('Lock with required acknowledge', async () => {
+  test('LockUnlock with Lock and required acknowledge', async () => {
     const item =
     {
       "state": "OFF",
@@ -1206,7 +1276,7 @@ describe('Test EXECUTE with Metadata', () => {
     });
   });
 
-  test('Lock with acknowledged challenge', async () => {
+  test('LockUnlock with Lock and acknowledged challenge', async () => {
     const getItemMock = jest.fn();
     const sendCommandMock = jest.fn();
     getItemMock.mockReturnValue(Promise.resolve());
@@ -1253,7 +1323,7 @@ describe('Test EXECUTE with Metadata', () => {
     });
   });
 
-  test('Lock inverted', async () => {
+  test('LockUnlock with Lock inverted', async () => {
     const getItemMock = jest.fn();
     const sendCommandMock = jest.fn();
     getItemMock.mockReturnValue(Promise.resolve());
@@ -1274,7 +1344,7 @@ describe('Test EXECUTE with Metadata', () => {
       "execution": [{
         "command": "action.devices.commands.LockUnlock",
         "params": {
-          lock: true
+          "lock": true
         }
       }]
     }];
@@ -1293,6 +1363,88 @@ describe('Test EXECUTE with Metadata', () => {
           "isLocked": true
         },
         "status": "SUCCESS"
+      }]
+    });
+  });
+
+  test('LockUnlock with Lock as Contact', async () => {
+    const getItemMock = jest.fn();
+    const sendCommandMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve());
+    sendCommandMock.mockReturnValue(Promise.resolve());
+
+    const apiHandler = {
+      getItem: getItemMock,
+      sendCommand: sendCommandMock
+    };
+
+    const commands = [{
+      "devices": [{
+        "customData": {
+          "itemType": "Contact"
+        },
+        "id": "MyLock"
+      }],
+      "execution": [{
+        "command": "action.devices.commands.LockUnlock",
+        "params": {
+          "lock": true
+        }
+      }]
+    }];
+
+    const payload = await new OpenHAB(apiHandler).handleExecute(commands);
+
+    expect(getItemMock).toHaveBeenCalledTimes(0);
+    expect(sendCommandMock).toHaveBeenCalledTimes(0);
+    expect(payload).toStrictEqual({
+      "commands": [{
+        "ids": [
+          "MyLock"
+        ],
+        "status": "ERROR",
+        "errorCode": "notSupported"
+      }]
+    });
+  });
+
+  test('OpenClose with OpenCloseDevice as Contact', async () => {
+    const getItemMock = jest.fn();
+    const sendCommandMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve());
+    sendCommandMock.mockReturnValue(Promise.resolve());
+
+    const apiHandler = {
+      getItem: getItemMock,
+      sendCommand: sendCommandMock
+    };
+
+    const commands = [{
+      "devices": [{
+        "customData": {
+          "itemType": "Contact"
+        },
+        "id": "MyLock"
+      }],
+      "execution": [{
+        "command": "action.devices.commands.OpenClose",
+        "params": {
+          "openPercent": 0
+        }
+      }]
+    }];
+
+    const payload = await new OpenHAB(apiHandler).handleExecute(commands);
+
+    expect(getItemMock).toHaveBeenCalledTimes(0);
+    expect(sendCommandMock).toHaveBeenCalledTimes(0);
+    expect(payload).toStrictEqual({
+      "commands": [{
+        "ids": [
+          "MyLock"
+        ],
+        "status": "ERROR",
+        "errorCode": "notSupported"
       }]
     });
   });


### PR DESCRIPTION
With this PR support for `Contact` items is introduced for Lock as well as OpenClose devices (Door, Window, etc.). Contacts will only report `OPEN/CLOSED` states.

We also introduce two new attributes for OpenClose devices:
`discreteOnlyOpenClose` Boolean. Optional. Defaults to `false`. When set to `true`, this indicates that the device must either be fully open or fully closed (that is, it does not support values between 0% and 100%). An example of such a device may be a valve.

`queryOnlyOpenClose` Boolean. Optional. Indicates if the device can only be queried for state information and cannot be controlled. Sensors that can only report open state should set this field to `true`.

Both will be automatically set to `true` for `Contact` items.


This PR will therefore partly resolve #160. There is no support for generic `String` or `Number` as requested yet as this is to unspecific.