### PR TITLE
Add thermostatTemperatureRange for Thermostat

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Switch HouseAlarm "House Alarm" { ga="SecuritySystem" [ tfaPin="1234" ] }
 Thermostat requires a group of items to be properly configured to be used with Google Assistant. The default temperature unit is Celsius. `{ ga="Thermostat" }`
 
 To change the temperature unit to Fahrenheit, add the config option `[ useFahrenheit=true ]` to the thermostat group.
+To set the temperature range your thermostat supports, add the config option `[ thermostatTemperatureRange="10,30" ]` to the thermostat group.
 
 There must be at least three items as members of the group:
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ NOTE: metadata is not (yet?) available via paperUI. Either you create your items
 
 #### Two-Factor-Authentication
 
-For some actions, Google recommends to use TFA (Two-Factor-Authentication) to prevent accidential or unauthorized triggers of sensitive actions. See [Two-factor authentication &nbsp;|&nbsp; Actions on Google Smart Home](https://developers.google.com/assistant/smarthome/develop/two-factor-authenticatiob).
+For some actions, Google recommends to use TFA (Two-Factor-Authentication) to prevent accidential or unauthorized triggers of sensitive actions. See [Two-factor authentication &nbsp;|&nbsp; Actions on Google Smart Home](https://developers.google.com/assistant/smarthome/develop/two-factor-authentication).
 
 The openHAB Google Assistant integration supports both _ackNeeded_ and _pinNeeded_. You can use both types on all devices types and traits.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -105,7 +105,7 @@ NOTE: metadata is not (yet?) available via paperUI. Either you create your items
 
 #### Two-Factor-Authentication
 
-For some actions, Google recommends to use TFA (Two-Factor-Authentication) to prevent accidential or unauthorized triggers of sensitive actions. See [Two-factor authentication &nbsp;|&nbsp; Actions on Google Smart Home](https://developers.google.com/assistant/smarthome/develop/two-factor-authenticatiob).
+For some actions, Google recommends to use TFA (Two-Factor-Authentication) to prevent accidential or unauthorized triggers of sensitive actions. See [Two-factor authentication &nbsp;|&nbsp; Actions on Google Smart Home](https://developers.google.com/assistant/smarthome/develop/two-factor-authentication).
 
 The openHAB Google Assistant integration supports both _ackNeeded_ and _pinNeeded_. You can use both types on all devices types and traits.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -125,6 +125,7 @@ Switch HouseAlarm "House Alarm" { ga="SecuritySystem" [ tfaPin="1234" ] }
 Thermostat requires a group of items to be properly configured to be used with Google Assistant. The default temperature unit is Celsius. `{ ga="Thermostat" }`
 
 To change the temperature unit to Fahrenheit, add the config option `[ useFahrenheit=true ]` to the thermostat group.
+To set the temperature range your thermostat supports, add the config option `[ thermostatTemperatureRange="10,30" ]` to the thermostat group.
 
 There must be at least three items as members of the group:
 

--- a/functions/devices.js
+++ b/functions/devices.js
@@ -599,9 +599,19 @@ class Thermostat extends GenericDevice {
   }
 
   static getAttributes(item) {
+    const config = getConfig(item);
     const attributes = {
       thermostatTemperatureUnit: this.usesFahrenheit(item) ? 'F' : 'C'
     };
+    if (('thermostatTemperatureRange' in config)) {
+      const range = config.thermostatTemperatureRange.split(',');
+      if (range.length > 1) {
+        attributes.thermostatTemperatureRange = {
+          minThresholdCelsius: parseFloat(range[0]),
+          maxThresholdCelsius: parseFloat(range[1])
+        }
+      }
+    }
     const members = this.getMembers(item);
     if (('thermostatTemperatureAmbient' in members) &&
       !('thermostatMode' in members) &&

--- a/tests/devices.metadata.test.js
+++ b/tests/devices.metadata.test.js
@@ -302,8 +302,8 @@ describe('Test Thermostat Device with Metadata', () => {
         }
       }
     })).toStrictEqual({
-      'availableThermostatModes': 'off,heat,cool,on,heatcool,auto,eco',
-      'thermostatTemperatureUnit': 'F',
+      availableThermostatModes: 'off,heat,cool,on,heatcool,auto,eco',
+      thermostatTemperatureUnit: 'F',
     });
 
     expect(Devices.Thermostat.getAttributes({
@@ -316,8 +316,8 @@ describe('Test Thermostat Device with Metadata', () => {
         }
       }
     })).toStrictEqual({
-      'availableThermostatModes': 'on,off',
-      'thermostatTemperatureUnit': 'C',
+      availableThermostatModes: 'on,off',
+      thermostatTemperatureUnit: 'C',
     });
 
     expect(Devices.Thermostat.getAttributes({
@@ -330,8 +330,42 @@ describe('Test Thermostat Device with Metadata', () => {
         }
       }
     })).toStrictEqual({
-      'availableThermostatModes': 'off,heat,eco,on,auto',
-      'thermostatTemperatureUnit': 'C',
+      availableThermostatModes: 'off,heat,eco,on,auto',
+      thermostatTemperatureUnit: 'C',
+    });
+
+    // test thermostatTemperatureRange attribute
+    expect(Devices.Thermostat.getAttributes({
+      metadata: {
+        ga: {
+          value: 'Thermostat',
+          config: {
+            thermostatTemperatureRange: '10,30'
+          }
+        }
+      }
+    })).toStrictEqual({
+      availableThermostatModes: 'off,heat,cool,on,heatcool,auto,eco',
+      thermostatTemperatureUnit: 'C',
+      thermostatTemperatureRange: {
+        minThresholdCelsius: 10.0,
+        maxThresholdCelsius: 30.0
+      }
+    });
+
+    // wrong value for thermostatTemperatureRange should not throw error
+    expect(Devices.Thermostat.getAttributes({
+      metadata: {
+        ga: {
+          value: 'Thermostat',
+          config: {
+            thermostatTemperatureRange: '100'
+          }
+        }
+      }
+    })).toStrictEqual({
+      availableThermostatModes: 'off,heat,cool,on,heatcool,auto,eco',
+      thermostatTemperatureUnit: 'C'
     });
   });
 


### PR DESCRIPTION
With this PR the config option `thermostatTemperatureRange` is added to define the minimum and maximum temperature the thermostat supports.

It needs to be added to the thermostat group items as metadata like `[ thermostatTemperatureRange="10,30" ]`.