### PR TITLE
Improve efficiency of Sync + Fix synonyms

### DIFF
--- a/functions/apihandler.js
+++ b/functions/apihandler.js
@@ -30,10 +30,11 @@ class ApiHandler {
   }
 
   getOptions(method = 'GET', itemName = '', length = 0) {
+    const queryString = '?metadata=ga,synonyms' + (itemName ? '' : '&fields=groupNames,groupType,name,label,metadata,tags,type');
     const options = {
       hostname: this._config.host,
       port: this._config.port,
-      path: this._config.path + (itemName ? itemName + '?metadata=ga' : '?metadata=ga&recursive=true'),
+      path: this._config.path + (itemName ? itemName : '') + queryString,
       method: method,
       headers: {
         'Accept': 'application/json'

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -34,6 +34,7 @@ class OpenHAB {
 		return this._apiHandler.getItems().then((items) => {
 			let discoveredDevicesList = [];
 			items.forEach((item) => {
+				item.members = items.filter((member) => member.groupNames && member.groupNames.includes(item.name));
 				const DeviceType = getDeviceForItem(item);
 				if (DeviceType) {
 					console.log(`openhabGoogleAssistant - handleSync - SYNC is adding: ${item.type}:${item.name} with type: ${DeviceType.type}`);

--- a/tests/__snapshots__/openhab.metadata.test.js.snap
+++ b/tests/__snapshots__/openhab.metadata.test.js.snap
@@ -335,3 +335,45 @@ Object {
   ],
 }
 `;
+
+exports[`Test SYNC with Metadata Thermostat Device 1`] = `
+Object {
+  "devices": Array [
+    Object {
+      "attributes": Object {
+        "availableThermostatModes": "off,heat,eco,auto",
+        "thermostatTemperatureUnit": "C",
+      },
+      "customData": Object {
+        "deviceType": "action.devices.types.THERMOSTAT",
+        "itemType": undefined,
+        "tfaAck": undefined,
+        "tfaPin": undefined,
+      },
+      "deviceInfo": Object {
+        "hwVersion": "2.5.0",
+        "manufacturer": "openHAB",
+        "model": "My Thermostat",
+        "swVersion": "2.5.0",
+      },
+      "id": "MyThermostat",
+      "name": Object {
+        "defaultNames": Array [
+          "My Thermostat",
+        ],
+        "name": "My Thermostat",
+        "nicknames": Array [
+          "My Thermostat",
+        ],
+      },
+      "roomHint": undefined,
+      "structureHint": undefined,
+      "traits": Array [
+        "action.devices.traits.TemperatureSetting",
+      ],
+      "type": "action.devices.types.THERMOSTAT",
+      "willReportState": false,
+    },
+  ],
+}
+`;

--- a/tests/openhab.metadata.test.js
+++ b/tests/openhab.metadata.test.js
@@ -157,6 +157,94 @@ describe('Test SYNC with Metadata', () => {
     expect(getItemsMock).toHaveBeenCalledTimes(1);
     expect(payload).toMatchSnapshot();
   });
+
+  test('Thermostat Device', async () => {
+    const items = [
+      {
+        "state": "NULL",
+        "metadata": {
+          "ga": {
+            "value": "Thermostat",
+            "config": {
+              "modes": "off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST:ON,eco=ECO,auto=AUTOMATIC"
+            }
+          }
+        },
+        "type": "Group",
+        "name": "MyThermostat",
+        "label": "My Thermostat",
+        "tags": [],
+        "groupNames": [],
+      },
+      {
+        "state": "AUTOMATIC",
+        "type": "String",
+        "name": "MyThermostat_Mode",
+        "label": "My Thermostat Mode",
+        "tags": [],
+        "groupNames": [
+          "MyThermostat"
+        ],
+      },
+      {
+        "state": "OFF",
+        "metadata": {
+          "ga": {
+            "value": "thermostatMode"
+          }
+        },
+        "type": "String",
+        "name": "MyThermostat_RadiatorMode",
+        "label": "My Thermostat Mode",
+        "tags": [],
+        "groupNames": [
+          "MyThermostat"
+        ],
+      },
+      {
+        "state": "6.0 °C",
+        "metadata": {
+          "ga": {
+            "value": "thermostatTemperatureSetpoint"
+          }
+        },
+        "type": "Number:Temperature",
+        "name": "MyThermostat_SetpointTemperature",
+        "label": "My Thermostat Setpoint Temperature",
+        "tags": [],
+        "groupNames": [
+          "MyThermostat"
+        ],
+      },
+      {
+        "state": "22.5 °C",
+        "metadata": {
+          "ga": {
+            "value": "thermostatTemperatureAmbient"
+          }
+        },
+        "type": "Number:Temperature",
+        "name": "MyThermostat_CurrentTemperature",
+        "label": "My Thermostat Current Temperature",
+        "tags": [],
+        "groupNames": [
+          "MyThermostat"
+        ],
+      }
+    ];
+    const getItemsMock = jest.fn();
+    getItemsMock.mockReturnValue(Promise.resolve(items));
+
+    const apiHandler = {
+      getItems: getItemsMock
+    };
+
+    const payload = await new OpenHAB(apiHandler).handleSync();
+
+    expect(getItemsMock).toHaveBeenCalledTimes(1);
+    expect(payload).toMatchSnapshot();
+  });
+
 });
 
 describe('Test QUERY with Metadata', () => {


### PR DESCRIPTION
With this PR we improve the efficiency during the SYNC of the devices.
We got rid of the "recursive" option which could make the payload super huge with complex structures. Since all information is already in the normal response, we stick with that and collect the group members on our own.
Additionally, only required fields are requested to make the payload even smaller.
Hopefully, this fixes some issues with timeouts and other errors during sync.

Furthermore, the synonyms were missed to retrieve all the time. This issue is also now fixed.