### PR TITLE
Add Temperature Sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,12 @@ Currently the following metadata values are supported (also depending on Googles
 * `Rollershutter { ga="Pergola" }`
 * `Rollershutter { ga="Shutter" }`
 * `Rollershutter { ga="Window" }`
-* `Group { ga="Thermostat" [ modes="..." ] }`
+* `Group { ga="Thermostat" [ modes="...", useFahrenheit=true ] }`
 * `Number { ga="thermostatTemperatureAmbient" }` as part of Thermostat group
 * `Number { ga="thermostatHumidityAmbient" }` as part of Thermostat group
 * `Number { ga="thermostatTemperatureSetpoint" }` as part of Thermostat group
 * `Number / String { ga="thermostatMode" }` as part of Thermostat group
+* `Number { ga="TemperatureSensor" } [ useFahrenheit=true ] `
 * `String { ga="Camera" [ protocols="hls,dash" ] }`
 
 _\* All Rollershutter devices can also be used with a Switch item with the limitation of only supporting open and close states._
@@ -300,6 +301,7 @@ E.g. `[ modes="off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto" ]` wil
 By default the integration will provide `"off,heat,cool,on,heatcool,auto,eco"`.
 
 You can also set up a Thermostat for using it as a temperature sensor. To do so, create a Thermostat group and only add one item member as "thermostatTemperatureAmbient".
+However, it is recommended to prefer the `TemperatureSensor` type for simple temperature reports (but currently no UI support in Google Assistant).
 
 #### Fans
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -51,11 +51,12 @@ Currently the following metadata values are supported (also depending on Googles
 * `Rollershutter { ga="Pergola" }`
 * `Rollershutter { ga="Shutter" }`
 * `Rollershutter { ga="Window" }`
-* `Group { ga="Thermostat" [ modes="..." ] }`
+* `Group { ga="Thermostat" [ modes="...", useFahrenheit=true ] }`
 * `Number { ga="thermostatTemperatureAmbient" }` as part of Thermostat group
 * `Number { ga="thermostatHumidityAmbient" }` as part of Thermostat group
 * `Number { ga="thermostatTemperatureSetpoint" }` as part of Thermostat group
 * `Number / String { ga="thermostatMode" }` as part of Thermostat group
+* `Number { ga="TemperatureSensor" } [ useFahrenheit=true ] `
 * `String { ga="Camera" [ protocols="hls,dash" ] }`
 
 _\* All Rollershutter devices can also be used with a Switch item with the limitation of only supporting open and close states._
@@ -145,6 +146,7 @@ E.g. `[ modes="off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto" ]` wil
 By default the integration will provide `"off,heat,cool,on,heatcool,auto,eco"`.
 
 You can also set up a Thermostat for using it as a temperature sensor. To do so, create a Thermostat group and only add one item member as "thermostatTemperatureAmbient".
+However, it is recommended to prefer the `TemperatureSensor` type for simple temperature reports (but currently no UI support in Google Assistant).
 
 #### Fans
 

--- a/tests/__snapshots__/openhab.metadata.test.js.snap
+++ b/tests/__snapshots__/openhab.metadata.test.js.snap
@@ -342,6 +342,45 @@ Object {
 }
 `;
 
+exports[`Test SYNC with Metadata Temperature Sensor Device 1`] = `
+Object {
+  "devices": Array [
+    Object {
+      "attributes": Object {
+        "queryOnlyTemperatureControl": true,
+        "temperatureUnitForUX": "F",
+      },
+      "customData": Object {
+        "itemType": "Number",
+      },
+      "deviceInfo": Object {
+        "hwVersion": "2.5.0",
+        "manufacturer": "openHAB",
+        "model": "Number:MySensor",
+        "swVersion": "2.5.0",
+      },
+      "id": "MySensor",
+      "name": Object {
+        "defaultNames": Array [
+          "My Sensor",
+        ],
+        "name": "My Sensor",
+        "nicknames": Array [
+          "My Sensor",
+        ],
+      },
+      "roomHint": undefined,
+      "structureHint": undefined,
+      "traits": Array [
+        "action.devices.traits.TemperatureControl",
+      ],
+      "type": "action.devices.types.SENSOR",
+      "willReportState": false,
+    },
+  ],
+}
+`;
+
 exports[`Test SYNC with Metadata Thermostat Device 1`] = `
 Object {
   "devices": Array [

--- a/tests/__snapshots__/openhab.metadata.test.js.snap
+++ b/tests/__snapshots__/openhab.metadata.test.js.snap
@@ -351,12 +351,16 @@ Object {
         "temperatureUnitForUX": "F",
       },
       "customData": Object {
+        "deviceType": "action.devices.types.SENSOR",
+        "inverted": false,
         "itemType": "Number",
+        "tfaAck": undefined,
+        "tfaPin": undefined,
       },
       "deviceInfo": Object {
         "hwVersion": "2.5.0",
         "manufacturer": "openHAB",
-        "model": "Number:MySensor",
+        "model": "My Sensor",
         "swVersion": "2.5.0",
       },
       "id": "MySensor",
@@ -391,6 +395,7 @@ Object {
       },
       "customData": Object {
         "deviceType": "action.devices.types.THERMOSTAT",
+        "inverted": false,
         "itemType": undefined,
         "tfaAck": undefined,
         "tfaPin": undefined,

--- a/tests/openhab.metadata.test.js
+++ b/tests/openhab.metadata.test.js
@@ -158,6 +158,37 @@ describe('Test SYNC with Metadata', () => {
     expect(payload).toMatchSnapshot();
   });
 
+  test('Temperature Sensor Device', async () => {
+    const items = [
+      {
+        "state": "14",
+        "metadata": {
+          "ga": {
+            "value": "TemperatureSensor",
+            "config": {
+              "useFahrenheit": true
+            }
+          }
+        },
+        "type": "Number",
+        "name": "MySensor",
+        "label": "My Sensor",
+        "tags": []
+      }
+    ];
+    const getItemsMock = jest.fn();
+    getItemsMock.mockReturnValue(Promise.resolve(items));
+
+    const apiHandler = {
+      getItems: getItemsMock
+    };
+
+    const payload = await new OpenHAB(apiHandler).handleSync();
+
+    expect(getItemsMock).toHaveBeenCalledTimes(1);
+    expect(payload).toMatchSnapshot();
+  });
+
   test('Thermostat Device', async () => {
     const items = [
       {
@@ -478,7 +509,43 @@ describe('Test QUERY with Metadata', () => {
       "devices": {
         "MyBlinds": {
           "openPercent": 0,
-          "online": true,
+          "online": true
+        },
+      },
+    });
+  });
+
+  test('Temperature Sensor', async () => {
+    const item =
+    {
+      "state": "20",
+      "type": "Number",
+      "name": "MySensor",
+      "metadata": {
+        "ga": {
+          "value": "TemperatureSensor"
+        }
+      }
+    };
+
+    const getItemMock = jest.fn();
+    getItemMock.mockReturnValue(Promise.resolve(item));
+
+    const apiHandler = {
+      getItem: getItemMock
+    };
+
+    const payload = await new OpenHAB(apiHandler).handleQuery([{
+      "id": "MySensor"
+    }]);
+
+    expect(getItemMock).toHaveBeenCalledTimes(1);
+    expect(payload).toStrictEqual({
+      "devices": {
+        "MySensor": {
+          "temperatureAmbientCelsius": 20,
+          "temperatureSetpointCelsius": 20,
+          "online": true
         },
       },
     });
@@ -517,7 +584,7 @@ describe('Test QUERY with Metadata', () => {
         "MyFan": {
           "on": true,
           "currentFanSpeedSetting": "50",
-          "online": true,
+          "online": true
         },
       },
     });


### PR DESCRIPTION
As it was reported multiple times that the current way of providing a temperature sensor using a thermostat device is not working nicely, this PR adds a new `TemperatureSensor` device type.
(See [Temperature Sensor and Google Assistant @ openHAB Community](https://community.openhab.org/t/temperature-sensor-and-google-assistant/95057))

With this new way we
a) Do not need the thermostat group item anymore
b) Only get response with the current temperature without the information "Thermostat is off"
c) Can not anymore see the value in the Google Home app, as sensors do not have any UI currently

Same as for thermostats we also can specify `useFahrenheit=true` if required.