### PR TITLE
Run tests with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test

--- a/tests/__snapshots__/openhab.metadata.test.js.snap
+++ b/tests/__snapshots__/openhab.metadata.test.js.snap
@@ -352,6 +352,7 @@ Object {
       },
       "customData": Object {
         "deviceType": "action.devices.types.THERMOSTAT",
+        "inverted": false,
         "itemType": undefined,
         "tfaAck": undefined,
         "tfaPin": undefined,


### PR DESCRIPTION
automated tests related to #143
also fixed snapshot test which was added in #169 and did not have the `inverted` property in the snapshot