### PR TITLE
Remove tag support

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -360,9 +360,6 @@ NOTE: metadata is not available via paperUI in openHAB v2. Either you create you
   }
   ```
 
-NOTE: Please be aware that for backward compatibilty also the former usage of tags (ref. [Google Assistant Action Documentation v2.5](https://www.openhab.org/v2.5/docs/ecosystem/google-assistant/)) to specify items to be exposed to Google Assistent is supported and may cause unexpected behavior.
-Items that contain tags that refer to a valid Google Assistent device will be exposed regardless of having metadata set. E.g.: `Switch MyBulb ["Lighting"]`.
-
 #### Two-Factor-Authentication
 
 For some actions, Google recommends to use TFA (Two-Factor-Authentication) to prevent accidential or unauthorized triggers of sensitive actions. See [Two-factor authentication &nbsp;|&nbsp; Actions on Google Smart Home](https://developers.google.com/assistant/smarthome/develop/two-factor-authentication).

--- a/functions/apihandler.js
+++ b/functions/apihandler.js
@@ -49,7 +49,7 @@ class ApiHandler {
    */
   getOptions(method = 'GET', itemName = '', length = 0) {
     const queryString =
-      '?metadata=ga,synonyms' + (itemName ? '' : '&fields=groupNames,groupType,name,label,metadata,tags,type');
+      '?metadata=ga,synonyms' + (itemName ? '' : '&fields=groupNames,groupType,name,label,metadata,type');
     const options = {
       hostname: this._config.host,
       port: this._config.port,

--- a/functions/devices/default.js
+++ b/functions/devices/default.js
@@ -22,10 +22,9 @@ class DefaultDevice {
    */
   static isCompatible(item) {
     return (
-      (item.metadata &&
-        item.metadata.ga &&
-        this.type.toLowerCase() === `action.devices.types.${item.metadata.ga.value}`.toLowerCase()) ||
-      this.hasTag(item, this.type.substr(21).replace('SWITCH', 'SWITCHABLE').replace('LIGHT', 'LIGHTING'))
+      item.metadata &&
+      item.metadata.ga &&
+      this.type.toLowerCase() === `action.devices.types.${item.metadata.ga.value}`.toLowerCase()
     );
   }
 
@@ -106,14 +105,6 @@ class DefaultDevice {
    */
   static getState(item) {
     return {};
-  }
-
-  /**
-   * @param {object} item
-   * @param {string} tag
-   */
-  static hasTag(item, tag) {
-    return (item.tags && item.tags.map((t) => t.toLowerCase()).includes(tag.toLowerCase())) || false;
   }
 }
 

--- a/functions/devices/thermostat.js
+++ b/functions/devices/thermostat.js
@@ -74,24 +74,6 @@ class Thermostat extends DefaultDevice {
           if (memberType) {
             members[memberType] = { name: member.name, state: member.state };
           }
-        } else {
-          if (
-            this.hasTag(member, 'HeatingCoolingMode') ||
-            this.hasTag(member, 'homekit:HeatingCoolingMode') ||
-            this.hasTag(member, 'homekit:TargetHeatingCoolingMode') ||
-            this.hasTag(member, 'homekit:CurrentHeatingCoolingMode')
-          ) {
-            members.thermostatMode = { name: member.name, state: member.state };
-          }
-          if (this.hasTag(member, 'TargetTemperature') || this.hasTag(member, 'homekit:TargetTemperature')) {
-            members.thermostatTemperatureSetpoint = { name: member.name, state: member.state };
-          }
-          if (this.hasTag(member, 'CurrentTemperature')) {
-            members.thermostatTemperatureAmbient = { name: member.name, state: member.state };
-          }
-          if (this.hasTag(member, 'CurrentHumidity')) {
-            members.thermostatHumidityAmbient = { name: member.name, state: member.state };
-          }
         }
       });
     }
@@ -100,7 +82,7 @@ class Thermostat extends DefaultDevice {
 
   static useFahrenheit(item) {
     const config = this.getConfig(item);
-    return config.thermostatTemperatureUnit === 'F' || config.useFahrenheit === true || this.hasTag(item, 'Fahrenheit');
+    return config.thermostatTemperatureUnit === 'F' || config.useFahrenheit === true;
   }
 
   static getModeMap(item) {

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -57,7 +57,11 @@ class OpenHAB {
    * @param {object} item
    */
   static getDeviceForItem(item) {
-    return Devices.find((device) => device.matchesItemType(item) && device.isCompatible(item));
+    return (
+      item.metadata &&
+      item.metadata.ga &&
+      Devices.find((device) => device.matchesItemType(item) && device.isCompatible(item))
+    );
   }
 
   /**
@@ -143,6 +147,7 @@ class OpenHAB {
   handleSync() {
     return this._apiHandler.getItems().then((items) => {
       let discoveredDevicesList = [];
+      items = items.filter((item) => item.metadata && item.metadata.ga);
       items.forEach((item) => {
         item.members = items.filter((member) => member.groupNames && member.groupNames.includes(item.name));
         const DeviceType = OpenHAB.getDeviceForItem(item);

--- a/tests/apihandler.test.js
+++ b/tests/apihandler.test.js
@@ -40,7 +40,7 @@ describe('ApiHandler', () => {
         },
         hostname: 'example.org',
         method: 'GET',
-        path: '/items/?metadata=ga,synonyms&fields=groupNames,groupType,name,label,metadata,tags,type',
+        path: '/items/?metadata=ga,synonyms&fields=groupNames,groupType,name,label,metadata,type',
         port: 443
       });
     });
@@ -125,7 +125,7 @@ describe('ApiHandler', () => {
 
     test('getItems', async () => {
       const scope = nock('https://example.org')
-        .get('/items/?metadata=ga,synonyms&fields=groupNames,groupType,name,label,metadata,tags,type')
+        .get('/items/?metadata=ga,synonyms&fields=groupNames,groupType,name,label,metadata,type')
         .reply(200, [{ name: 'TestItem' }]);
       const result = await apiHandler.getItems();
       expect(result).toStrictEqual([{ name: 'TestItem' }]);
@@ -134,7 +134,7 @@ describe('ApiHandler', () => {
 
     test('getItems failed', async () => {
       const scope = nock('https://example.org')
-        .get('/items/?metadata=ga,synonyms&fields=groupNames,groupType,name,label,metadata,tags,type')
+        .get('/items/?metadata=ga,synonyms&fields=groupNames,groupType,name,label,metadata,type')
         .reply(400, {});
       let error = {};
       try {

--- a/tests/devices/default.test.js
+++ b/tests/devices/default.test.js
@@ -91,11 +91,4 @@ describe('Default Device', () => {
     });
     expect(metadata.name.name).toBe('DefaultDevice');
   });
-
-  test('hasTag', () => {
-    expect(Device.hasTag({}, 'testtag')).toBe(false);
-    expect(Device.hasTag({ tags: ['test'] }, 'testtag')).toBe(false);
-    expect(Device.hasTag({ tags: ['testtag'] }, 'testtag')).toBe(true);
-    expect(Device.hasTag({ tags: ['TestTag'] }, 'testtag')).toBe(true);
-  });
 });

--- a/tests/devices/thermostat.test.js
+++ b/tests/devices/thermostat.test.js
@@ -55,12 +55,6 @@ describe('Thermostat Device', () => {
       };
       expect(Device.useFahrenheit(item)).toBe(true);
     });
-    test('useFahrenheit tag', () => {
-      const item = {
-        tags: ['Fahrenheit']
-      };
-      expect(Device.useFahrenheit(item)).toBe(true);
-    });
   });
 
   describe('getAttributes', () => {
@@ -233,51 +227,6 @@ describe('Thermostat Device', () => {
         thermostatTemperatureSetpointLow: {
           name: 'Low',
           state: '5'
-        },
-        thermostatTemperatureAmbient: {
-          name: 'Temperature',
-          state: '20'
-        },
-        thermostatHumidityAmbient: {
-          name: 'Humidity',
-          state: '50'
-        }
-      });
-    });
-
-    test('getMembers with tags', () => {
-      const item = {
-        members: [
-          {
-            name: 'Mode',
-            state: 'on',
-            tags: ['HeatingCoolingMode']
-          },
-          {
-            name: 'Setpoint',
-            state: '20',
-            tags: ['TargetTemperature']
-          },
-          {
-            name: 'Temperature',
-            state: '20',
-            tags: ['CurrentTemperature']
-          },
-          {
-            name: 'Humidity',
-            state: '50',
-            tags: ['CurrentHumidity']
-          }
-        ]
-      };
-      expect(Device.getMembers(item)).toStrictEqual({
-        thermostatMode: {
-          name: 'Mode',
-          state: 'on'
-        },
-        thermostatTemperatureSetpoint: {
-          name: 'Setpoint',
-          state: '20'
         },
         thermostatTemperatureAmbient: {
           name: 'Temperature',

--- a/tests/openhab.test.js
+++ b/tests/openhab.test.js
@@ -9,14 +9,8 @@ describe('OpenHAB', () => {
   });
 
   describe('getDeviceForItem', () => {
-    test('getDeviceForItem switch tag', () => {
+    test('getDeviceForItem switch', () => {
       const device = OpenHAB.getDeviceForItem({ type: 'Switch', metadata: { ga: { value: 'Switch' } } });
-      expect(device).not.toBeUndefined();
-      expect(device.name).toBe('Switch');
-    });
-
-    test('getDeviceForItem switch tag', () => {
-      const device = OpenHAB.getDeviceForItem({ type: 'Switch', tags: ['Switchable'] });
       expect(device).not.toBeUndefined();
       expect(device.name).toBe('Switch');
     });


### PR DESCRIPTION
As already discussed, I would like to get rid of the legacy tag support.
This caused so much confusion in the past and is just not required anymore.
There will be an announcement on when this will happen to let people migrate their config if required.