### PR TITLE
Make sceneReversible configurable for scene device

### DIFF
--- a/functions/devices/scene.js
+++ b/functions/devices/scene.js
@@ -13,9 +13,10 @@ class Scene extends DefaultDevice {
     return ['Switch'];
   }
 
-  static getAttributes() {
+  static getAttributes(item) {
+    const config = this.getConfig(item);
     return {
-      sceneReversible: true
+      sceneReversible: config.sceneReversible !== false
     };
   }
 }

--- a/tests/devices/scene.test.js
+++ b/tests/devices/scene.test.js
@@ -20,39 +20,41 @@ describe('Scene Device', () => {
     expect(Device.matchesItemType({ type: 'Group', groupType: 'String' })).toBe(false);
   });
 
-  test('getAttributes', () => {
-    expect(Device.getAttributes()).toStrictEqual({
-      sceneReversible: true
+  describe('getAttributes', () => {
+    test('getAttributes no config', () => {
+      expect(Device.getAttributes()).toStrictEqual({
+        sceneReversible: true
+      });
     });
-  });
 
-  test('getAttributes with sceneReversible = true', () => {
-    const item = {
-      metadata: {
-        ga: {
-          config: {
-            sceneReversible: true
+    test('getAttributes with sceneReversible = true', () => {
+      const item = {
+        metadata: {
+          ga: {
+            config: {
+              sceneReversible: true
+            }
           }
         }
-      }
-    };
-    expect(Device.getAttributes(item)).toStrictEqual({
-      sceneReversible: true
+      };
+      expect(Device.getAttributes(item)).toStrictEqual({
+        sceneReversible: true
+      });
     });
-  });
 
-  test('getAttributes with sceneReversible = false', () => {
-    const item = {
-      metadata: {
-        ga: {
-          config: {
-            sceneReversible: false
+    test('getAttributes with sceneReversible = false', () => {
+      const item = {
+        metadata: {
+          ga: {
+            config: {
+              sceneReversible: false
+            }
           }
         }
-      }
-    };
-    expect(Device.getAttributes(item)).toStrictEqual({
-      sceneReversible: false
+      };
+      expect(Device.getAttributes(item)).toStrictEqual({
+        sceneReversible: false
+      });
     });
   });
 

--- a/tests/devices/scene.test.js
+++ b/tests/devices/scene.test.js
@@ -26,6 +26,36 @@ describe('Scene Device', () => {
     });
   });
 
+  test('getAttributes with sceneReversible = true', () => {
+    const item = {
+      metadata: {
+        ga: {
+          config: {
+            sceneReversible: true
+          }
+        }
+      }
+    };
+    expect(Device.getAttributes(item)).toStrictEqual({
+      sceneReversible: true
+    });
+  });
+
+  test('getAttributes with sceneReversible = false', () => {
+    const item = {
+      metadata: {
+        ga: {
+          config: {
+            sceneReversible: false
+          }
+        }
+      }
+    };
+    expect(Device.getAttributes(item)).toStrictEqual({
+      sceneReversible: false
+    });
+  });
+
   test('getState', () => {
     expect(Device.getState({})).toStrictEqual({});
   });


### PR DESCRIPTION
I added the possibility to adjust sceneReversible meta for scenes, see https://developers.google.com/assistant/smarthome/traits/scene

As sceneReversible is currently set to true, I made it the default setting. Therefore users need to set sceneReversible explicitly to false.

