### PR TITLE
Add volumeMaxLevel option to Speaker and TV

### DIFF
--- a/functions/devices/speaker.js
+++ b/functions/devices/speaker.js
@@ -15,6 +15,9 @@ class Speaker extends DefaultDevice {
       volumeMaxLevel: 100,
       volumeCanMuteAndUnmute: false
     };
+    if ('volumeMaxLevel' in config) {
+      attributes.volumeMaxLevel = Number(config.volumeMaxLevel);
+    }
     if ('volumeDefaultPercentage' in config) {
       attributes.volumeDefaultPercentage = Number(config.volumeDefaultPercentage);
     }

--- a/functions/devices/tv.js
+++ b/functions/devices/tv.js
@@ -28,6 +28,9 @@ class TV extends DefaultDevice {
     };
     if ('tvVolume' in members) {
       attributes.volumeMaxLevel = 100;
+      if ('volumeMaxLevel' in config) {
+        attributes.volumeMaxLevel = Number(config.volumeMaxLevel);
+      }
       if ('volumeDefaultPercentage' in config) {
         attributes.volumeDefaultPercentage = Number(config.volumeDefaultPercentage);
       }

--- a/tests/devices/speaker.test.js
+++ b/tests/devices/speaker.test.js
@@ -35,12 +35,13 @@ describe('Speaker Device', () => {
       });
     });
 
-    test('getAttributes volumeDefaultPercentage, levelStepSize', () => {
+    test('getAttributes volumeDefaultPercentage, volumeMaxLevel, levelStepSize', () => {
       const item = {
         metadata: {
           ga: {
             config: {
               volumeDefaultPercentage: '20',
+              volumeMaxLevel: '90',
               levelStepSize: '10'
             }
           }
@@ -48,7 +49,7 @@ describe('Speaker Device', () => {
       };
       expect(Device.getAttributes(item)).toStrictEqual({
         volumeCanMuteAndUnmute: false,
-        volumeMaxLevel: 100,
+        volumeMaxLevel: 90,
         volumeDefaultPercentage: 20,
         levelStepSize: 10
       });

--- a/tests/devices/tv.test.js
+++ b/tests/devices/tv.test.js
@@ -148,6 +148,7 @@ describe('TV Device', () => {
           ga: {
             config: {
               volumeDefaultPercentage: '20',
+              volumeMaxLevel: '80',
               levelStepSize: '10'
             }
           }
@@ -166,7 +167,7 @@ describe('TV Device', () => {
         levelStepSize: 10,
         volumeCanMuteAndUnmute: false,
         volumeDefaultPercentage: 20,
-        volumeMaxLevel: 100
+        volumeMaxLevel: 80
       });
     });
 


### PR DESCRIPTION
Add the option to define `volumeMaxLevel` for TV and Speaker devices.


TODO: I have to test it, how Google handles that value...