### PR TITLE
Adjust new camera stream protocols

### DIFF
--- a/functions/devices/camera.js
+++ b/functions/devices/camera.js
@@ -12,7 +12,9 @@ class Camera extends DefaultDevice {
   static getAttributes(item) {
     const config = this.getConfig(item);
     return {
-      cameraStreamSupportedProtocols: (config.protocols || 'hls,dash').split(',').map((s) => s.trim()),
+      cameraStreamSupportedProtocols: (config.protocols || 'hls,dash,smooth_stream,progressive_mp4')
+        .split(',')
+        .map((s) => s.trim()),
       cameraStreamNeedAuthToken: config.token ? true : false,
       cameraStreamNeedDrmEncryption: false
     };

--- a/tests/devices/camera.test.js
+++ b/tests/devices/camera.test.js
@@ -30,7 +30,7 @@ describe('Camera Device', () => {
         }
       };
       expect(Device.getAttributes(item)).toStrictEqual({
-        cameraStreamSupportedProtocols: ['hls', 'dash'],
+        cameraStreamSupportedProtocols: ['hls', 'dash', 'smooth_stream', 'progressive_mp4'],
         cameraStreamNeedAuthToken: false,
         cameraStreamNeedDrmEncryption: false
       });


### PR DESCRIPTION
As I was going through the documentation I noticed that supported values for the `cameraStreamSupportedProtocols` have changed. So I adjusted those.

See https://developers.google.com/assistant/smarthome/traits/camerastream