### PR TITLE
Use package version as swVersion

### DIFF
--- a/functions/devices/default.js
+++ b/functions/devices/default.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-unused-vars */
+const packageVersion = require('../../package.json').version;
+
 class DefaultDevice {
   static get type() {
     return '';
@@ -79,8 +81,8 @@ class DefaultDevice {
       deviceInfo: {
         manufacturer: 'openHAB',
         model: `${itemType}:${item.name}`,
-        hwVersion: '2.5.0',
-        swVersion: '2.5.0'
+        hwVersion: '3.0.0',
+        swVersion: packageVersion
       },
       attributes: this.getAttributes(item),
       customData: {

--- a/tests/devices/default.test.js
+++ b/tests/devices/default.test.js
@@ -1,4 +1,5 @@
 const Device = require('../../functions/devices/default.js');
+const packageVersion = require('../../package.json').version;
 
 describe('Default Device', () => {
   const item = {
@@ -44,10 +45,10 @@ describe('Default Device', () => {
         pinNeeded: '1234'
       },
       deviceInfo: {
-        hwVersion: '2.5.0',
         manufacturer: 'openHAB',
         model: 'Number:DefaultDevice',
-        swVersion: '2.5.0'
+        hwVersion: '3.0.0',
+        swVersion: packageVersion
       },
       id: 'DefaultDevice',
       name: {

--- a/tests/openhab.test.js
+++ b/tests/openhab.test.js
@@ -1,4 +1,5 @@
 const OpenHAB = require('../functions/openhab.js');
+const packageVersion = require('../package.json').version;
 
 describe('OpenHAB', () => {
   test('getCommandType', () => {
@@ -111,10 +112,10 @@ describe('OpenHAB', () => {
               itemType: 'Switch'
             },
             deviceInfo: {
-              hwVersion: '2.5.0',
               manufacturer: 'openHAB',
               model: 'Switch:SwitchItem',
-              swVersion: '2.5.0'
+              hwVersion: '3.0.0',
+              swVersion: packageVersion
             },
             id: 'SwitchItem',
             name: {
@@ -174,10 +175,10 @@ describe('OpenHAB', () => {
               itemType: 'Switch'
             },
             deviceInfo: {
-              hwVersion: '2.5.0',
               manufacturer: 'openHAB',
               model: 'Switch:SwitchItem',
-              swVersion: '2.5.0'
+              hwVersion: '3.0.0',
+              swVersion: packageVersion
             },
             id: 'SwitchItem',
             name: {
@@ -200,10 +201,10 @@ describe('OpenHAB', () => {
               itemType: 'Group'
             },
             deviceInfo: {
-              hwVersion: '2.5.0',
               manufacturer: 'openHAB',
               model: 'Group:TVItem',
-              swVersion: '2.5.0'
+              hwVersion: '3.0.0',
+              swVersion: packageVersion
             },
             id: 'TVItem',
             name: {


### PR DESCRIPTION
Idea was to use the version of this project as `swVersion` in the metadata, so that users would be able to actually tell, what version is deployed.

Unfortunately, this value is not displayed in Google Home. :/ 