### PR TITLE
Support types with dimension

### DIFF
--- a/functions/devices/default.js
+++ b/functions/devices/default.js
@@ -33,11 +33,8 @@ class DefaultDevice {
    * @param {object} item
    */
   static matchesItemType(item) {
-    return (
-      !this.requiredItemTypes.length ||
-      this.requiredItemTypes.includes(item.type) ||
-      (item.type === 'Group' && item.groupType && this.requiredItemTypes.includes(item.groupType))
-    );
+    const itemType = (item.type === 'Group' && item.groupType ? item.groupType : item.type || '').split(':')[0];
+    return !this.requiredItemTypes.length || this.requiredItemTypes.includes(itemType);
   }
 
   /**

--- a/functions/devices/default.js
+++ b/functions/devices/default.js
@@ -33,8 +33,10 @@ class DefaultDevice {
    * @param {object} item
    */
   static matchesItemType(item) {
-    const itemType = (item.type === 'Group' && item.groupType ? item.groupType : item.type || '').split(':')[0];
-    return !this.requiredItemTypes.length || this.requiredItemTypes.includes(itemType);
+    return (
+      !this.requiredItemTypes.length ||
+      this.requiredItemTypes.includes((item.groupType || item.type || '').split(':')[0])
+    );
   }
 
   /**
@@ -56,7 +58,7 @@ class DefaultDevice {
    */
   static getMetadata(item) {
     const config = this.getConfig(item);
-    const itemType = item.type === 'Group' && item.groupType ? item.groupType : item.type;
+    const itemType = item.groupType || item.type;
     const deviceName = config.name || item.label || item.name;
     const metadata = {
       id: item.name,

--- a/functions/devices/openclosedevice.js
+++ b/functions/devices/openclosedevice.js
@@ -11,7 +11,7 @@ class OpenCloseDevice extends DefaultDevice {
       discreteOnlyOpenClose: this.getConfig(item).discreteOnly === true,
       queryOnlyOpenClose: this.getConfig(item).queryOnly === true
     };
-    const itemType = item.type === 'Group' && item.groupType ? item.groupType : item.type;
+    const itemType = item.groupType || item.type;
     if (itemType === 'Switch') {
       attributes.discreteOnlyOpenClose = true;
     }
@@ -28,7 +28,7 @@ class OpenCloseDevice extends DefaultDevice {
 
   static getState(item) {
     let state = 0;
-    const itemType = item.type === 'Group' && item.groupType ? item.groupType : item.type;
+    const itemType = item.groupType || item.type;
     if (itemType === 'Rollershutter') {
       state = Number(item.state);
     } else {

--- a/tests/devices/default.test.js
+++ b/tests/devices/default.test.js
@@ -22,6 +22,10 @@ describe('Default Device', () => {
     }
   };
 
+  test('matchesItemType', () => {
+    expect(Device.matchesItemType({ type: 'Number' })).toBe(true);
+  });
+
   test('getConfig', () => {
     expect(Device.getConfig(item)).toStrictEqual({
       ackNeeded: true,

--- a/tests/devices/temperaturesensor.test.js
+++ b/tests/devices/temperaturesensor.test.js
@@ -15,6 +15,7 @@ describe('TemperatureSensor Device', () => {
 
   test('matchesItemType', () => {
     expect(Device.matchesItemType({ type: 'Number' })).toBe(true);
+    expect(Device.matchesItemType({ type: 'Number:Temperature' })).toBe(true);
     expect(Device.matchesItemType({ type: 'Dimmer' })).toBe(false);
     expect(Device.matchesItemType({ type: 'Group', groupType: 'Dimmer' })).toBe(false);
     expect(Device.matchesItemType({ type: 'Group', groupType: 'Number' })).toBe(true);


### PR DESCRIPTION
As reported in #209 there is an issue with Number types that also provide a dimension. This case was not taken into account and thus the device compatibility check failed.

This PR fixes the behavior and only uses the part before the colon sign for type comparison.

- Fixes #209 