### PR TITLE
Add separate power switch for specialcolorlight

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -72,11 +72,12 @@ Color  { ga="Light" [ colorTemperatureRange="2000,9000" ] }
 |---|---|
 | **Device Type** | [Light](https://developers.google.com/assistant/smarthome/guides/light) |
 | **Supported Traits** | [OnOff](https://developers.google.com/assistant/smarthome/traits/onoff), [ColorSetting](https://developers.google.com/assistant/smarthome/traits/colorsetting), [Brightness](https://developers.google.com/assistant/smarthome/traits/brightness) |
-| **Supported Items** | Group as `light` with two Number or Dimmer members as `lightBrightness` & `lightColorTemperature` |
+| **Supported Items** | Group as `light` with the following members: Number or Dimmer as `lightBrightness`, Number or Dimmer as `lightColorTemperature`, (optional) Switch as `lightPower` |
 | **Configuration** | (optional) `useKelvin=true/false`<br>(optional) `colorTemperatureRange="minK,maxK"`<br>_Hint: if you do not set `useKelvin=true` then `colorTemperatureRange` is required_ |
 
 ```shell
 Group  lightGroup { ga="Light" [ useKelvin=true, colorTemperatureRange="2000,9000" ] }
+Switch powerItem      (lightGroup) { ga="lightPower" }
 Dimmer brightnessItem (lightGroup) { ga="lightBrightness" }
 Number colorItem      (lightGroup) { ga="lightColorTemperature" }
 ```

--- a/functions/commands/onoff.js
+++ b/functions/commands/onoff.js
@@ -19,6 +19,9 @@ class OnOff extends DefaultCommand {
     const deviceType = this.getDeviceType(device);
     if (deviceType === 'SpecialColorLight') {
       const members = SpecialColorLight.getMembers(item);
+      if ('lightPower' in members) {
+        return members.lightPower.name;
+      }
       if ('lightBrightness' in members) {
         return members.lightBrightness.name;
       }

--- a/functions/devices/specialcolorlight.js
+++ b/functions/devices/specialcolorlight.js
@@ -37,9 +37,14 @@ class SpecialColorLight extends DefaultDevice {
     const members = this.getMembers(item);
     for (const member in members) {
       switch (member) {
+        case 'lightPower':
+          state.on = members[member].state === 'ON';
+          break;
         case 'lightBrightness':
           state.brightness = Number(members[member].state) || 0;
-          state.on = state.brightness > 0;
+          if (!('lightPower' in members)) {
+            state.on = state.brightness > 0;
+          }
           break;
         case 'lightColorTemperature':
           try {
@@ -59,7 +64,7 @@ class SpecialColorLight extends DefaultDevice {
   }
 
   static getMembers(item) {
-    const supportedMembers = ['lightBrightness', 'lightColorTemperature'];
+    const supportedMembers = ['lightBrightness', 'lightColorTemperature', 'lightPower'];
     const members = Object();
     if (item.members && item.members.length) {
       item.members.forEach((member) => {

--- a/tests/commands/onoff.test.js
+++ b/tests/commands/onoff.test.js
@@ -22,6 +22,7 @@ describe('OnOff Command', () => {
       expect(() => {
         Command.getItemName({ name: 'Item' }, { customData: { deviceType: 'SpecialColorLight' } });
       }).toThrow();
+
       const item = {
         members: [
           {
@@ -35,12 +36,27 @@ describe('OnOff Command', () => {
         ]
       };
       expect(Command.getItemName(item, { customData: { deviceType: 'SpecialColorLight' } })).toBe('BrightnessItem');
+
+      const item_power = {
+        members: [
+          {
+            name: 'PowerItem',
+            metadata: {
+              ga: {
+                value: 'lightPower'
+              }
+            }
+          }
+        ]
+      };
+      expect(Command.getItemName(item_power, { customData: { deviceType: 'SpecialColorLight' } })).toBe('PowerItem');
     });
 
     test('getItemName TV', () => {
       expect(() => {
         Command.getItemName({ name: 'Item' }, { customData: { deviceType: 'TV' } });
       }).toThrow();
+
       const item = {
         members: [
           {

--- a/tests/devices/specialcolorlight.test.js
+++ b/tests/devices/specialcolorlight.test.js
@@ -172,6 +172,46 @@ describe('SpecialColorLight Device', () => {
         }
       });
     });
+
+    test('getState zero brightness', () => {
+      const item = {
+        type: 'Group',
+        metadata: {
+          ga: {
+            value: 'LIGHT',
+            config: {
+              colorTemperatureRange: '1000,4000'
+            }
+          }
+        },
+        members: [
+          {
+            state: '0',
+            metadata: {
+              ga: {
+                value: 'lightBrightness'
+              }
+            }
+          },
+          {
+            state: '20',
+            metadata: {
+              ga: {
+                value: 'lightColorTemperature'
+              }
+            }
+          }
+        ]
+      };
+      expect(Device.getState(item)).toStrictEqual({
+        on: false,
+        brightness: 0,
+        color: {
+          temperatureK: 3400
+        }
+      });
+    });
+
     test('getState use kelvin', () => {
       const item = {
         type: 'Group',
@@ -208,6 +248,53 @@ describe('SpecialColorLight Device', () => {
         brightness: 50,
         color: {
           temperatureK: 2000
+        }
+      });
+    });
+
+    test('getState lightPower', () => {
+      const item = {
+        type: 'Group',
+        metadata: {
+          ga: {
+            value: 'LIGHT',
+            config: {
+              colorTemperatureRange: '1000,4000'
+            }
+          }
+        },
+        members: [
+          {
+            state: 'OFF',
+            metadata: {
+              ga: {
+                value: 'lightPower'
+              }
+            }
+          },
+          {
+            state: '50',
+            metadata: {
+              ga: {
+                value: 'lightBrightness'
+              }
+            }
+          },
+          {
+            state: '20',
+            metadata: {
+              ga: {
+                value: 'lightColorTemperature'
+              }
+            }
+          }
+        ]
+      };
+      expect(Device.getState(item)).toStrictEqual({
+        on: false,
+        brightness: 50,
+        color: {
+          temperatureK: 3400
         }
       });
     });


### PR DESCRIPTION
This PR implements feature request #214.

It adds an optional separate Switch member to the "SpecialColorLight" device type.

| | |
|---|---|
| **Device Type** | [Light](https://developers.google.com/assistant/smarthome/guides/light) |
| **Supported Traits** | [OnOff](https://developers.google.com/assistant/smarthome/traits/onoff), [ColorSetting](https://developers.google.com/assistant/smarthome/traits/colorsetting), [Brightness](https://developers.google.com/assistant/smarthome/traits/brightness) |
| **Supported Items** | Group as `light` with the following members: Number or Dimmer as `lightBrightness`, Number or Dimmer as `lightColorTemperature`, (optional) Switch as `lightPower` |
| **Configuration** | (optional) `useKelvin=true/false`<br>(optional) `colorTemperatureRange="minK,maxK"`<br>_Hint: if you do not set `useKelvin=true` then `colorTemperatureRange` is required_ |

```shell
Group  lightGroup { ga="Light" [ useKelvin=true, colorTemperatureRange="2000,9000" ] }
Switch powerItem      (lightGroup) { ga="lightPower" }
Dimmer brightnessItem (lightGroup) { ga="lightBrightness" }
Number colorItem      (lightGroup) { ga="lightColorTemperature" }
```