### PR TITLE
Add http support for apihandler

### DIFF
--- a/functions/apihandler.js
+++ b/functions/apihandler.js
@@ -18,6 +18,7 @@
  * @author Michael Krug - Rework
  *
  */
+const http = require('http');
 const https = require('https');
 
 class ApiHandler {
@@ -49,7 +50,9 @@ class ApiHandler {
    */
   getOptions(method = 'GET', itemName = '', length = 0) {
     const queryString =
-      '?metadata=ga,synonyms' + (itemName ? '' : '&fields=groupNames,groupType,name,label,metadata,type');
+      method === 'GET'
+        ? '?metadata=ga,synonyms' + (itemName ? '' : '&fields=groupNames,groupType,name,label,metadata,type')
+        : '';
     const options = {
       hostname: this._config.host,
       port: this._config.port,
@@ -80,9 +83,12 @@ class ApiHandler {
   getItem(itemName = '') {
     const options = this.getOptions('GET', itemName);
     return new Promise((resolve, reject) => {
-      const req = https.request(options, (response) => {
+      const protocol = options.port === 443 ? https : http;
+      const req = protocol.request(options, (response) => {
         if (200 !== response.statusCode) {
-          console.error('getItem failed for path: ' + options.path + ' code: ' + response.statusCode);
+          console.error(
+            'openhabGoogleAssistant - getItem - failed for path: ' + options.path + ' code: ' + response.statusCode
+          );
           reject({ statusCode: response.statusCode, message: 'getItem failed' });
           return;
         }
@@ -114,9 +120,12 @@ class ApiHandler {
   sendCommand(itemName, payload) {
     const options = this.getOptions('POST', itemName, payload.length);
     return new Promise((resolve, reject) => {
-      const req = https.request(options, (response) => {
+      const protocol = options.port === 443 ? https : http;
+      const req = protocol.request(options, (response) => {
         if (![200, 201].includes(response.statusCode)) {
-          console.error('sendCommand failed for path: ' + options.path + ' code: ' + response.statusCode);
+          console.error(
+            'openhabGoogleAssistant - sendCommand - failed for path: ' + options.path + ' code: ' + response.statusCode
+          );
           reject({ statusCode: response.statusCode, message: 'sendCommand failed' });
           return;
         }

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -188,8 +188,6 @@ class OpenHAB {
               errorCode:
                 error.statusCode == 404
                   ? 'deviceNotFound'
-                  : error.statusCode == 400
-                  ? 'notSupported'
                   : error.statusCode == 406
                   ? 'deviceNotReady'
                   : 'deviceOffline'

--- a/tests/apihandler.test.js
+++ b/tests/apihandler.test.js
@@ -68,7 +68,7 @@ describe('ApiHandler', () => {
         },
         hostname: 'example.org',
         method: 'POST',
-        path: '/items/TestItem?metadata=ga,synonyms',
+        path: '/items/TestItem',
         port: 443
       });
     });
@@ -96,24 +96,9 @@ describe('ApiHandler', () => {
     test('getItem', async () => {
       const scope = nock('https://example.org')
         .get('/items/TestItem?metadata=ga,synonyms')
-        .reply(200, [{ name: 'TestItem' }]);
+        .reply(200, { name: 'TestItem' });
       const result = await apiHandler.getItem('TestItem');
-      expect(result).toStrictEqual([{ name: 'TestItem' }]);
-      expect(scope.isDone()).toBe(true);
-    });
-
-    test('getItem failed', async () => {
-      const scope = nock('https://example.org').get('/items/TestItem?metadata=ga,synonyms').reply(400, {});
-      let error = {};
-      try {
-        await apiHandler.getItem('TestItem');
-      } catch (e) {
-        error = e;
-      }
-      expect(error).toStrictEqual({
-        message: 'getItem failed',
-        statusCode: 400
-      });
+      expect(result).toStrictEqual({ name: 'TestItem' });
       expect(scope.isDone()).toBe(true);
     });
   });
@@ -157,7 +142,7 @@ describe('ApiHandler', () => {
 
     test('sendCommand', async () => {
       const scope = nock('https://example.org')
-        .post('/items/TestItem?metadata=ga,synonyms')
+        .post('/items/TestItem')
         .reply(200, [{ name: 'TestItem' }]);
       const result = await apiHandler.sendCommand('TestItem', 'OFF');
       expect(result).toBeUndefined();
@@ -165,7 +150,7 @@ describe('ApiHandler', () => {
     });
 
     test('sendCommand failed', async () => {
-      const scope = nock('https://example.org').post('/items/TestItem?metadata=ga,synonyms').reply(400, {});
+      const scope = nock('https://example.org').post('/items/TestItem').reply(400, {});
       let error = {};
       try {
         await apiHandler.sendCommand('TestItem', 'OFF');

--- a/tests/openhab.test.js
+++ b/tests/openhab.test.js
@@ -8,12 +8,10 @@ describe('OpenHAB', () => {
     expect(command.name).toBe('OnOff');
   });
 
-  describe('getDeviceForItem', () => {
-    test('getDeviceForItem switch', () => {
-      const device = OpenHAB.getDeviceForItem({ type: 'Switch', metadata: { ga: { value: 'Switch' } } });
-      expect(device).not.toBeUndefined();
-      expect(device.name).toBe('Switch');
-    });
+  test('getDeviceForItem', () => {
+    const device = OpenHAB.getDeviceForItem({ type: 'Switch', metadata: { ga: { value: 'Switch' } } });
+    expect(device).not.toBeUndefined();
+    expect(device.name).toBe('Switch');
   });
 
   test('setTokenFromHeader', () => {
@@ -336,41 +334,6 @@ describe('OpenHAB', () => {
         devices: {
           TestItem: {
             errorCode: 'deviceNotReady',
-            status: 'ERROR'
-          }
-        }
-      });
-    });
-
-    // there is currently no case
-    xtest('handleQuery notSupported', async () => {
-      getItemMock.mockReturnValue(
-        Promise.resolve({
-          name: 'TestItem',
-          type: 'Group',
-          state: 'NULL',
-          metadata: {
-            ga: {
-              value: 'Thermostat',
-              config: {
-                modes: 'on=1,off=2'
-              }
-            }
-          },
-          members: [
-            {
-              state: '3',
-              metadata: { ga: { value: 'thermostatMode' } }
-            }
-          ]
-        })
-      );
-      const result = await openHAB.handleQuery([{ id: 'TestItem' }]);
-      expect(getItemMock).toHaveBeenCalledTimes(1);
-      expect(result).toStrictEqual({
-        devices: {
-          TestItem: {
-            errorCode: 'notSupported',
             status: 'ERROR'
           }
         }


### PR DESCRIPTION
When hosting the function on your own, one might have the openHAB cloud instance only accessible via HTTP, which might be okay when just running locally.
To support that case, we hereby add support for HTTP connections next to HTTPS.

Other changes:
- Do not send query parameter on POST
- Remove invalid error cases