### PR TITLE
Fix sensor state format

### DIFF
--- a/functions/devices/sensor.js
+++ b/functions/devices/sensor.js
@@ -15,19 +15,15 @@ class Sensor extends DefaultDevice {
 
   static getAttributes(item) {
     const config = this.getConfig(item);
-    const attributes = { sensorStatesSupported: {} };
-    if ('sensorName' in config) {
-      attributes.sensorStatesSupported = {
-        name: config.sensorName
-      };
-    }
+    if (!('sensorName' in config) || (!('valueUnit' in config) && !('states' in config))) return {};
+    const attributes = { sensorStatesSupported: [{ name: config.sensorName }] };
     if ('valueUnit' in config) {
-      attributes.sensorStatesSupported.numericCapabilities = {
+      attributes.sensorStatesSupported[0].numericCapabilities = {
         rawValueUnit: config.valueUnit
       };
     }
     if ('states' in config) {
-      attributes.sensorStatesSupported.descriptiveCapabilities = {
+      attributes.sensorStatesSupported[0].descriptiveCapabilities = {
         availableStates: config.states.split(',').map((s) => s.trim().split('=')[0].trim())
       };
     }
@@ -37,11 +33,13 @@ class Sensor extends DefaultDevice {
   static getState(item) {
     const config = this.getConfig(item);
     return {
-      currentSensorStateData: {
-        name: config.sensorName,
-        currentSensorState: this.translateStateToGoogle(item),
-        rawValue: Number(item.state) || 0
-      }
+      currentSensorStateData: [
+        {
+          name: config.sensorName,
+          currentSensorState: this.translateStateToGoogle(item),
+          rawValue: Number(item.state) || 0
+        }
+      ]
     };
   }
 

--- a/tests/devices/sensor.test.js
+++ b/tests/devices/sensor.test.js
@@ -53,7 +53,7 @@ describe('Sensor Device', () => {
           }
         }
       };
-      expect(Device.getAttributes(item)).toStrictEqual({ sensorStatesSupported: {} });
+      expect(Device.getAttributes(item)).toStrictEqual({});
     });
 
     test('getAttributes states', () => {
@@ -69,15 +69,17 @@ describe('Sensor Device', () => {
         }
       };
       expect(Device.getAttributes(item)).toStrictEqual({
-        sensorStatesSupported: {
-          descriptiveCapabilities: {
-            availableStates: ['good', 'moderate', 'poor']
-          },
-          name: 'Sensor',
-          numericCapabilities: {
-            rawValueUnit: 'AQI'
+        sensorStatesSupported: [
+          {
+            descriptiveCapabilities: {
+              availableStates: ['good', 'moderate', 'poor']
+            },
+            name: 'Sensor',
+            numericCapabilities: {
+              rawValueUnit: 'AQI'
+            }
           }
-        }
+        ]
       });
     });
   });
@@ -97,11 +99,13 @@ describe('Sensor Device', () => {
         state: '10'
       };
       expect(Device.getState(item)).toStrictEqual({
-        currentSensorStateData: {
-          currentSensorState: 'good',
-          name: 'Sensor',
-          rawValue: 10
-        }
+        currentSensorStateData: [
+          {
+            currentSensorState: 'good',
+            name: 'Sensor',
+            rawValue: 10
+          }
+        ]
       });
     });
 
@@ -119,11 +123,13 @@ describe('Sensor Device', () => {
         state: '20'
       };
       expect(Device.getState(item)).toStrictEqual({
-        currentSensorStateData: {
-          currentSensorState: '',
-          name: 'Sensor',
-          rawValue: 20
-        }
+        currentSensorStateData: [
+          {
+            currentSensorState: '',
+            name: 'Sensor',
+            rawValue: 20
+          }
+        ]
       });
     });
   });


### PR DESCRIPTION
While working on extended Fan capabilities, I noticed that the format of the `sensorStatesSupported` and `currentSensorStateData` was incorrectly implemented.
This is now fixed.

Reference: https://developers.google.com/assistant/smarthome/traits/sensorstate