### PR TITLE
Rework device matching - Store members in customData

### DIFF
--- a/functions/apihandler.js
+++ b/functions/apihandler.js
@@ -49,7 +49,9 @@ class ApiHandler {
    */
   getOptions(method = 'GET', itemName = '', length = 0) {
     const queryString =
-      '?metadata=ga,synonyms' + (itemName ? '' : '&fields=groupNames,groupType,name,label,metadata,type');
+      method === 'GET'
+        ? '?metadata=ga,synonyms' + (itemName ? '' : '&fields=groupNames,groupType,name,label,metadata,type')
+        : '';
     const options = {
       hostname: this._config.host,
       port: this._config.port,

--- a/functions/commands/appselect.js
+++ b/functions/commands/appselect.js
@@ -17,10 +17,10 @@ class AppSelect extends DefaultCommand {
     return true;
   }
 
-  static getItemName(item) {
-    const members = TV.getMembers(item);
+  static getItemName(device) {
+    const members = (device.customData && device.customData.members) || {};
     if ('tvApplication' in members) {
-      return members.tvApplication.name;
+      return members.tvApplication;
     }
     throw { statusCode: 400 };
   }

--- a/functions/commands/brightnessabsolute.js
+++ b/functions/commands/brightnessabsolute.js
@@ -1,5 +1,4 @@
 const DefaultCommand = require('./default.js');
-const SpecialColorLight = require('../devices/specialcolorlight.js');
 
 class BrightnessAbsolute extends DefaultCommand {
   static get type() {
@@ -10,19 +9,15 @@ class BrightnessAbsolute extends DefaultCommand {
     return 'brightness' in params && typeof params.brightness === 'number';
   }
 
-  static requiresItem(device) {
-    return this.getDeviceType(device) === 'SpecialColorLight';
-  }
-
-  static getItemName(item, device) {
+  static getItemName(device) {
     if (this.getDeviceType(device) === 'SpecialColorLight') {
-      const members = SpecialColorLight.getMembers(item);
+      const members = (device.customData && device.customData.members) || {};
       if ('lightBrightness' in members) {
-        return members.lightBrightness.name;
+        return members.lightBrightness;
       }
       throw { statusCode: 400 };
     }
-    return item.name;
+    return device.id;
   }
 
   static convertParamsToValue(params) {

--- a/functions/commands/colorabsolutetemperature.js
+++ b/functions/commands/colorabsolutetemperature.js
@@ -1,5 +1,4 @@
 const DefaultCommand = require('./default.js');
-const SpecialColorLight = require('../devices/specialcolorlight.js');
 const rgb2hsv = require('../utilities.js').rgb2hsv;
 const kelvin2rgb = require('../utilities.js').kelvin2rgb;
 
@@ -17,28 +16,29 @@ class ColorAbsoluteTemperature extends DefaultCommand {
     );
   }
 
-  static requiresItem() {
-    return true;
+  static requiresItem(device) {
+    return this.getDeviceType(device) !== 'SpecialColorLight';
   }
 
-  static getItemName(item, device) {
+  static getItemName(device) {
     if (this.getDeviceType(device) === 'SpecialColorLight') {
-      const members = SpecialColorLight.getMembers(item);
+      const members = (device.customData && device.customData.members) || {};
       if ('lightColorTemperature' in members) {
-        return members.lightColorTemperature.name;
+        return members.lightColorTemperature;
       }
       throw { statusCode: 400 };
     }
-    return item.name;
+    return device.id;
   }
 
   static convertParamsToValue(params, item, device) {
     if (this.getDeviceType(device) === 'SpecialColorLight') {
       try {
-        if (SpecialColorLight.useKelvin(item)) {
+        const customData = device.customData || {};
+        if (customData.useKelvin) {
           return params.color.temperature.toString();
         }
-        const { temperatureMinK, temperatureMaxK } = SpecialColorLight.getAttributes(item).colorTemperatureRange;
+        const { temperatureMinK, temperatureMaxK } = customData.colorTemperatureRange;
         return (
           100 -
           ((params.color.temperature - temperatureMinK) / (temperatureMaxK - temperatureMinK)) * 100

--- a/functions/commands/default.js
+++ b/functions/commands/default.js
@@ -43,11 +43,10 @@ class DefaultCommand {
   }
 
   /**
-   * @param {object} item
    * @param {object} device
    */
-  static getItemName(item, device) {
-    return item.name;
+  static getItemName(device) {
+    return device.id;
   }
 
   /**
@@ -68,7 +67,7 @@ class DefaultCommand {
    * @param {object} device
    */
   static isInverted(device) {
-    return device.customData && device.customData.inverted === true;
+    return !!(device.customData && device.customData.inverted === true);
   }
 
   /**
@@ -164,7 +163,7 @@ class DefaultCommand {
             return;
           }
 
-          const targetItem = this.getItemName(item, device);
+          const targetItem = this.getItemName(device);
           const targetValue = this.convertParamsToValue(params, item, device);
           let sendCommandPromise = Promise.resolve();
           if (typeof targetItem === 'string' && typeof targetValue === 'string') {

--- a/functions/commands/medianext.js
+++ b/functions/commands/medianext.js
@@ -1,19 +1,14 @@
 const DefaultCommand = require('./default.js');
-const TV = require('../devices/tv.js');
 
 class MediaNext extends DefaultCommand {
   static get type() {
     return 'action.devices.commands.mediaNext';
   }
 
-  static requiresItem() {
-    return true;
-  }
-
-  static getItemName(item) {
-    const members = TV.getMembers(item);
+  static getItemName(device) {
+    const members = (device.customData && device.customData.members) || {};
     if ('tvTransport' in members) {
-      return members.tvTransport.name;
+      return members.tvTransport;
     }
     throw { statusCode: 400 };
   }

--- a/functions/commands/mediapause.js
+++ b/functions/commands/mediapause.js
@@ -1,19 +1,14 @@
 const DefaultCommand = require('./default.js');
-const TV = require('../devices/tv.js');
 
 class MediaPause extends DefaultCommand {
   static get type() {
     return 'action.devices.commands.mediaPause';
   }
 
-  static requiresItem() {
-    return true;
-  }
-
-  static getItemName(item) {
-    const members = TV.getMembers(item);
+  static getItemName(device) {
+    const members = (device.customData && device.customData.members) || {};
     if ('tvTransport' in members) {
-      return members.tvTransport.name;
+      return members.tvTransport;
     }
     throw { statusCode: 400 };
   }

--- a/functions/commands/mediaprevious.js
+++ b/functions/commands/mediaprevious.js
@@ -1,19 +1,14 @@
 const DefaultCommand = require('./default.js');
-const TV = require('../devices/tv.js');
 
 class MediaPrevious extends DefaultCommand {
   static get type() {
     return 'action.devices.commands.mediaPrevious';
   }
 
-  static requiresItem() {
-    return true;
-  }
-
-  static getItemName(item) {
-    const members = TV.getMembers(item);
+  static getItemName(device) {
+    const members = (device.customData && device.customData.members) || {};
     if ('tvTransport' in members) {
-      return members.tvTransport.name;
+      return members.tvTransport;
     }
     throw { statusCode: 400 };
   }

--- a/functions/commands/mediaresume.js
+++ b/functions/commands/mediaresume.js
@@ -1,19 +1,14 @@
 const DefaultCommand = require('./default.js');
-const TV = require('../devices/tv.js');
 
 class MediaResume extends DefaultCommand {
   static get type() {
     return 'action.devices.commands.mediaResume';
   }
 
-  static requiresItem() {
-    return true;
-  }
-
-  static getItemName(item) {
-    const members = TV.getMembers(item);
+  static getItemName(device) {
+    const members = (device.customData && device.customData.members) || {};
     if ('tvTransport' in members) {
-      return members.tvTransport.name;
+      return members.tvTransport;
     }
     throw { statusCode: 400 };
   }

--- a/functions/commands/mute.js
+++ b/functions/commands/mute.js
@@ -1,5 +1,4 @@
 const DefaultCommand = require('./default.js');
-const TV = require('../devices/tv.js');
 
 class Mute extends DefaultCommand {
   static get type() {
@@ -10,32 +9,26 @@ class Mute extends DefaultCommand {
     return 'mute' in params && typeof params.mute === 'boolean';
   }
 
-  static requiresItem(device) {
-    return this.getDeviceType(device) === 'TV';
-  }
-
-  static getItemName(item, device) {
+  static getItemName(device) {
     if (this.getDeviceType(device) === 'TV') {
-      const members = TV.getMembers(item);
+      const members = (device.customData && device.customData.members) || {};
       if ('tvMute' in members) {
-        return members.tvMute.name;
+        return members.tvMute;
       }
       if ('tvVolume' in members) {
-        return members.tvVolume.name;
+        return members.tvVolume;
       }
       throw { statusCode: 400 };
     }
-    return item.name;
+    return device.id;
   }
 
   static convertParamsToValue(params, item, device) {
     let itemType = this.getItemType(device);
     if (this.getDeviceType(device) === 'TV') {
-      const members = TV.getMembers(item);
+      const members = (device.customData && device.customData.members) || {};
       if ('tvMute' in members) {
         itemType = 'Switch';
-      } else if ('tvVolume' in members) {
-        itemType = 'Dimmer';
       }
     }
     let mute = params.mute;

--- a/functions/commands/onoff.js
+++ b/functions/commands/onoff.js
@@ -1,6 +1,4 @@
 const DefaultCommand = require('./default.js');
-const SpecialColorLight = require('../devices/specialcolorlight.js');
-const TV = require('../devices/tv.js');
 
 class OnOff extends DefaultCommand {
   static get type() {
@@ -11,27 +9,22 @@ class OnOff extends DefaultCommand {
     return 'on' in params && typeof params.on === 'boolean';
   }
 
-  static requiresItem(device) {
-    return ['SpecialColorLight', 'TV'].includes(this.getDeviceType(device));
-  }
-
-  static getItemName(item, device) {
+  static getItemName(device) {
     const deviceType = this.getDeviceType(device);
+    const members = (device.customData && device.customData.members) || {};
     if (deviceType === 'SpecialColorLight') {
-      const members = SpecialColorLight.getMembers(item);
       if ('lightBrightness' in members) {
-        return members.lightBrightness.name;
+        return members.lightBrightness;
       }
       throw { statusCode: 400 };
     }
     if (deviceType === 'TV') {
-      const members = TV.getMembers(item);
       if ('tvPower' in members) {
-        return members.tvPower.name;
+        return members.tvPower;
       }
       throw { statusCode: 400 };
     }
-    return item.name;
+    return device.id;
   }
 
   static convertParamsToValue(params, _, device) {

--- a/functions/commands/selectchannel.js
+++ b/functions/commands/selectchannel.js
@@ -18,10 +18,10 @@ class SelectChannel extends DefaultCommand {
     return true;
   }
 
-  static getItemName(item) {
-    const members = TV.getMembers(item);
+  static getItemName(device) {
+    const members = (device.customData && device.customData.members) || {};
     if ('tvChannel' in members) {
-      return members.tvChannel.name;
+      return members.tvChannel;
     }
     throw { statusCode: 400 };
   }

--- a/functions/commands/setinput.js
+++ b/functions/commands/setinput.js
@@ -1,5 +1,4 @@
 const DefaultCommand = require('./default.js');
-const TV = require('../devices/tv.js');
 
 class SetInput extends DefaultCommand {
   static get type() {
@@ -10,14 +9,10 @@ class SetInput extends DefaultCommand {
     return 'newInput' in params && typeof params.newInput === 'string';
   }
 
-  static requiresItem() {
-    return true;
-  }
-
-  static getItemName(item) {
-    const members = TV.getMembers(item);
+  static getItemName(device) {
+    const members = (device.customData && device.customData.members) || {};
     if ('tvInput' in members) {
-      return members.tvInput.name;
+      return members.tvInput;
     }
     throw { statusCode: 400 };
   }

--- a/functions/commands/setvolume.js
+++ b/functions/commands/setvolume.js
@@ -1,5 +1,4 @@
 const DefaultCommand = require('./default.js');
-const TV = require('../devices/tv.js');
 
 class SetVolume extends DefaultCommand {
   static get type() {
@@ -10,19 +9,15 @@ class SetVolume extends DefaultCommand {
     return 'volumeLevel' in params && typeof params.volumeLevel === 'number';
   }
 
-  static requiresItem(device) {
-    return this.getDeviceType(device) === 'TV';
-  }
-
-  static getItemName(item, device) {
+  static getItemName(device) {
     if (this.getDeviceType(device) === 'TV') {
-      const members = TV.getMembers(item);
+      const members = (device.customData && device.customData.members) || {};
       if ('tvVolume' in members) {
-        return members.tvVolume.name;
+        return members.tvVolume;
       }
       throw { statusCode: 400 };
     }
-    return item.name;
+    return device.id;
   }
 
   static convertParamsToValue(params) {

--- a/functions/commands/thermostatsetmode.js
+++ b/functions/commands/thermostatsetmode.js
@@ -14,10 +14,10 @@ class ThermostatSetMode extends DefaultCommand {
     return true;
   }
 
-  static getItemName(item) {
-    const members = Thermostat.getMembers(item);
+  static getItemName(device) {
+    const members = (device.customData && device.customData.members) || {};
     if ('thermostatMode' in members) {
-      return members.thermostatMode.name;
+      return members.thermostatMode;
     }
     throw { statusCode: 400 };
   }

--- a/functions/commands/thermostattemperaturesetpoint.js
+++ b/functions/commands/thermostattemperaturesetpoint.js
@@ -15,10 +15,10 @@ class ThermostatTemperatureSetpoint extends DefaultCommand {
     return true;
   }
 
-  static getItemName(item) {
-    const members = Thermostat.getMembers(item);
+  static getItemName(device) {
+    const members = (device.customData && device.customData.members) || {};
     if ('thermostatTemperatureSetpoint' in members) {
-      return members.thermostatTemperatureSetpoint.name;
+      return members.thermostatTemperatureSetpoint;
     }
     throw { statusCode: 400 };
   }

--- a/functions/commands/thermostattemperaturesetpointhigh.js
+++ b/functions/commands/thermostattemperaturesetpointhigh.js
@@ -17,10 +17,10 @@ class ThermostatTemperatureSetpointHigh extends DefaultCommand {
     return true;
   }
 
-  static getItemName(item) {
-    const members = Thermostat.getMembers(item);
+  static getItemName(device) {
+    const members = (device.customData && device.customData.members) || {};
     if ('thermostatTemperatureSetpointHigh' in members) {
-      return members.thermostatTemperatureSetpointHigh.name;
+      return members.thermostatTemperatureSetpointHigh;
     }
     throw { statusCode: 400 };
   }

--- a/functions/commands/thermostattemperaturesetpointlow.js
+++ b/functions/commands/thermostattemperaturesetpointlow.js
@@ -14,11 +14,10 @@ class ThermostatTemperatureSetpointLow extends DefaultCommand {
   static requiresItem() {
     return true;
   }
-
-  static getItemName(item) {
-    const members = Thermostat.getMembers(item);
+  static getItemName(device) {
+    const members = (device.customData && device.customData.members) || {};
     if ('thermostatTemperatureSetpointLow' in members) {
-      return members.thermostatTemperatureSetpointLow.name;
+      return members.thermostatTemperatureSetpointLow;
     }
     throw { statusCode: 400 };
   }

--- a/functions/commands/volumerelative.js
+++ b/functions/commands/volumerelative.js
@@ -14,15 +14,15 @@ class VolumeRelative extends DefaultCommand {
     return true;
   }
 
-  static getItemName(item, device) {
+  static getItemName(device) {
     if (this.getDeviceType(device) === 'TV') {
-      const members = TV.getMembers(item);
+      const members = (device.customData && device.customData.members) || {};
       if ('tvVolume' in members) {
-        return members.tvVolume.name;
+        return members.tvVolume;
       }
       throw { statusCode: 400 };
     }
-    return item.name;
+    return device.id;
   }
 
   static convertParamsToValue(params, item, device) {

--- a/functions/devices/default.js
+++ b/functions/devices/default.js
@@ -20,8 +20,8 @@ class DefaultDevice {
   /**
    * @param {object} item
    */
-  static isCompatible(item) {
-    return (
+  static matchesDeviceType(item) {
+    return !!(
       item.metadata &&
       item.metadata.ga &&
       this.type.toLowerCase() === `action.devices.types.${item.metadata.ga.value}`.toLowerCase()
@@ -32,7 +32,7 @@ class DefaultDevice {
    * @param {object} item
    */
   static matchesItemType(item) {
-    return (
+    return !!(
       !this.requiredItemTypes.length ||
       this.requiredItemTypes.includes((item.groupType || item.type || '').split(':')[0])
     );
@@ -96,6 +96,13 @@ class DefaultDevice {
     }
     if (typeof config.pinNeeded === 'string' || typeof config.tfaPin === 'string') {
       metadata.customData.pinNeeded = config.pinNeeded || config.tfaPin;
+    }
+    if (typeof this.getMembers === 'function') {
+      const members = this.getMembers(item);
+      metadata.customData.members = {};
+      for (const member in members) {
+        metadata.customData.members[member] = members[member].name;
+      }
     }
     return metadata;
   }

--- a/functions/devices/sensor.js
+++ b/functions/devices/sensor.js
@@ -8,13 +8,20 @@ class Sensor extends DefaultDevice {
   static getTraits() {
     return ['action.devices.traits.SensorState'];
   }
-  static matchesItemType(item) {
-    const config = this.getConfig(item);
-    return 'sensorName' in config && ('valueUnit' in config || 'states' in config);
+
+  static get requiredItemTypes() {
+    return ['Number', 'String', 'Dimmer', 'Switch', 'Rollershutter', 'Contact'];
+  }
+
+  static matchesDeviceType(item) {
+    return super.matchesDeviceType(item) && !!this.getAttributes(item).sensorStatesSupported;
   }
 
   static getAttributes(item) {
     const config = this.getConfig(item);
+    if (!('sensorName' in config) || (!('valueUnit' in config) && !('states' in config))) {
+      return {};
+    }
     const attributes = { sensorStatesSupported: {} };
     if ('sensorName' in config) {
       attributes.sensorStatesSupported = {

--- a/functions/devices/specialcolorlight.js
+++ b/functions/devices/specialcolorlight.js
@@ -9,10 +9,14 @@ class SpecialColorLight extends DefaultDevice {
     return ['action.devices.traits.OnOff', 'action.devices.traits.Brightness', 'action.devices.traits.ColorSetting'];
   }
 
-  static matchesItemType(item) {
-    return (
-      item.type === 'Group' &&
-      Object.keys(this.getMembers(item)).length > 1 &&
+  static get requiredItemTypes() {
+    return ['Group'];
+  }
+
+  static matchesDeviceType(item) {
+    return !!(
+      super.matchesDeviceType(item) &&
+      Object.keys(this.getMembers(item)).length === 2 &&
       (this.useKelvin(item) || !!this.getAttributes(item).colorTemperatureRange)
     );
   }
@@ -30,6 +34,13 @@ class SpecialColorLight extends DefaultDevice {
       }
     }
     return attributes;
+  }
+
+  static getMetadata(item) {
+    const metadata = super.getMetadata(item);
+    metadata.customData.colorTemperatureRange = this.getAttributes(item).colorTemperatureRange;
+    metadata.customData.useKelvin = this.useKelvin(item);
+    return metadata;
   }
 
   static getState(item) {
@@ -75,8 +86,7 @@ class SpecialColorLight extends DefaultDevice {
   }
 
   static useKelvin(item) {
-    const config = this.getConfig(item);
-    return config.useKelvin === true;
+    return this.getConfig(item).useKelvin === true;
   }
 }
 

--- a/functions/devices/temperaturesensor.js
+++ b/functions/devices/temperaturesensor.js
@@ -21,7 +21,7 @@ class TemperatureSensor extends DefaultDevice {
     return ['Number'];
   }
 
-  static isCompatible(item = {}) {
+  static matchesDeviceType(item = {}) {
     return item.metadata && item.metadata.ga && item.metadata.ga.value.toLowerCase() == 'temperaturesensor';
   }
 

--- a/functions/devices/thermostat.js
+++ b/functions/devices/thermostat.js
@@ -10,8 +10,12 @@ class Thermostat extends DefaultDevice {
     return ['action.devices.traits.TemperatureSetting'];
   }
 
-  static matchesItemType(item) {
-    return item.type === 'Group' && Object.keys(this.getMembers(item)).length > 0;
+  static get requiredItemTypes() {
+    return ['Group'];
+  }
+
+  static matchesDeviceType(item) {
+    return super.matchesDeviceType(item) && Object.keys(this.getMembers(item)).length > 0;
   }
 
   static getAttributes(item) {

--- a/functions/devices/tv.js
+++ b/functions/devices/tv.js
@@ -16,9 +16,12 @@ class TV extends DefaultDevice {
     if ('tvApplication' in members) traits.push('action.devices.traits.AppSelector');
     return traits;
   }
+  static get requiredItemTypes() {
+    return ['Group'];
+  }
 
-  static matchesItemType(item) {
-    return item.type === 'Group' && Object.keys(this.getMembers(item)).length > 0;
+  static matchesDeviceType(item) {
+    return super.matchesDeviceType(item) && Object.keys(this.getMembers(item)).length > 0;
   }
 
   static getAttributes(item) {

--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -60,7 +60,7 @@ class OpenHAB {
     return (
       item.metadata &&
       item.metadata.ga &&
-      Devices.find((device) => device.matchesItemType(item) && device.isCompatible(item))
+      Devices.find((device) => device.matchesItemType(item) && device.matchesDeviceType(item))
     );
   }
 

--- a/tests/apihandler.test.js
+++ b/tests/apihandler.test.js
@@ -68,7 +68,7 @@ describe('ApiHandler', () => {
         },
         hostname: 'example.org',
         method: 'POST',
-        path: '/items/TestItem?metadata=ga,synonyms',
+        path: '/items/TestItem',
         port: 443
       });
     });
@@ -96,24 +96,9 @@ describe('ApiHandler', () => {
     test('getItem', async () => {
       const scope = nock('https://example.org')
         .get('/items/TestItem?metadata=ga,synonyms')
-        .reply(200, [{ name: 'TestItem' }]);
+        .reply(200, { name: 'TestItem' });
       const result = await apiHandler.getItem('TestItem');
-      expect(result).toStrictEqual([{ name: 'TestItem' }]);
-      expect(scope.isDone()).toBe(true);
-    });
-
-    test('getItem failed', async () => {
-      const scope = nock('https://example.org').get('/items/TestItem?metadata=ga,synonyms').reply(400, {});
-      let error = {};
-      try {
-        await apiHandler.getItem('TestItem');
-      } catch (e) {
-        error = e;
-      }
-      expect(error).toStrictEqual({
-        message: 'getItem failed',
-        statusCode: 400
-      });
+      expect(result).toStrictEqual({ name: 'TestItem' });
       expect(scope.isDone()).toBe(true);
     });
   });
@@ -157,7 +142,7 @@ describe('ApiHandler', () => {
 
     test('sendCommand', async () => {
       const scope = nock('https://example.org')
-        .post('/items/TestItem?metadata=ga,synonyms')
+        .post('/items/TestItem')
         .reply(200, [{ name: 'TestItem' }]);
       const result = await apiHandler.sendCommand('TestItem', 'OFF');
       expect(result).toBeUndefined();
@@ -165,7 +150,7 @@ describe('ApiHandler', () => {
     });
 
     test('sendCommand failed', async () => {
-      const scope = nock('https://example.org').post('/items/TestItem?metadata=ga,synonyms').reply(400, {});
+      const scope = nock('https://example.org').post('/items/TestItem').reply(400, {});
       let error = {};
       try {
         await apiHandler.sendCommand('TestItem', 'OFF');

--- a/tests/commands/appselect.test.js
+++ b/tests/commands/appselect.test.js
@@ -16,21 +16,16 @@ describe('appSelect Command', () => {
 
   test('getItemName', () => {
     expect(() => {
-      Command.getItemName({ name: 'Item' });
+      Command.getItemName({ id: 'Item' });
     }).toThrow();
-    const item = {
-      members: [
-        {
-          name: 'ApplicationItem',
-          metadata: {
-            ga: {
-              value: 'tvApplication'
-            }
-          }
+    const device = {
+      customData: {
+        members: {
+          tvApplication: 'ApplicationItem'
         }
-      ]
+      }
     };
-    expect(Command.getItemName(item)).toBe('ApplicationItem');
+    expect(Command.getItemName(device)).toBe('ApplicationItem');
   });
 
   test('convertParamsToValue', () => {

--- a/tests/commands/brightnessabsolute.test.js
+++ b/tests/commands/brightnessabsolute.test.js
@@ -7,32 +7,22 @@ describe('BrightnessAbsolute Command', () => {
     expect(Command.validateParams({ brightness: '100' })).toBe(false);
   });
 
-  test('requiresItem', () => {
-    expect(Command.requiresItem({})).toBe(false);
-    expect(Command.requiresItem({ customData: {} })).toBe(false);
-    expect(Command.requiresItem({ customData: { deviceType: 'SpecialColorLight' } })).toBe(true);
-  });
-
   test('getItemName', () => {
-    expect(Command.getItemName({ name: 'Item' }, {})).toBe('Item');
-    expect(Command.getItemName({ name: 'Item' }, { customData: {} })).toBe('Item');
+    expect(Command.getItemName({ id: 'Item' })).toBe('Item');
+    expect(Command.getItemName({ id: 'Item', customData: {} })).toBe('Item');
     expect(() => {
-      Command.getItemName({ name: 'Item' }, { customData: { deviceType: 'SpecialColorLight' } });
+      Command.getItemName({ id: 'Item', customData: { deviceType: 'SpecialColorLight' } });
     }).toThrow();
-    const item = {
-      name: 'Item',
-      members: [
-        {
-          name: 'BrightnessItem',
-          metadata: {
-            ga: {
-              value: 'lightBrightness'
-            }
-          }
+    const device = {
+      id: 'Item',
+      customData: {
+        deviceType: 'SpecialColorLight',
+        members: {
+          lightBrightness: 'BrightnessItem'
         }
-      ]
+      }
     };
-    expect(Command.getItemName(item, { customData: { deviceType: 'SpecialColorLight' } })).toBe('BrightnessItem');
+    expect(Command.getItemName(device)).toBe('BrightnessItem');
   });
 
   test('convertParamsToValue', () => {

--- a/tests/commands/colorabsolutetemperature.test.js
+++ b/tests/commands/colorabsolutetemperature.test.js
@@ -14,29 +14,27 @@ describe('ColorAbsoluteTemperature Command', () => {
   });
 
   test('requiresItem', () => {
-    expect(Command.requiresItem()).toBe(true);
+    expect(Command.requiresItem({})).toBe(true);
+    expect(Command.requiresItem({ customData: { deviceType: 'SpecialColorLight' } })).toBe(false);
   });
 
   test('getItemName', () => {
-    expect(Command.getItemName({ name: 'Item' }, {})).toBe('Item');
-    expect(Command.getItemName({ name: 'Item' }, { customData: {} })).toBe('Item');
+    expect(Command.getItemName({ id: 'Item' })).toBe('Item');
+    expect(Command.getItemName({ id: 'Item', customData: {} })).toBe('Item');
     expect(() => {
-      Command.getItemName({ name: 'Item' }, { customData: { deviceType: 'SpecialColorLight' } });
+      Command.getItemName({ id: 'Item', customData: { deviceType: 'SpecialColorLight' } });
     }).toThrow();
-    const item = {
-      name: 'Item',
-      members: [
-        {
-          name: 'ColorItem',
-          metadata: {
-            ga: {
-              value: 'lightColorTemperature'
-            }
+    expect(
+      Command.getItemName({
+        id: 'Item',
+        customData: {
+          deviceType: 'SpecialColorLight',
+          members: {
+            lightColorTemperature: 'ColorItem'
           }
         }
-      ]
-    };
-    expect(Command.getItemName(item, { customData: { deviceType: 'SpecialColorLight' } })).toBe('ColorItem');
+      })
+    ).toBe('ColorItem');
   });
 
   describe('convertParamsToValue', () => {
@@ -45,33 +43,41 @@ describe('ColorAbsoluteTemperature Command', () => {
     });
 
     test('convertParamsToValue SpecialColorLight', () => {
-      const item = {
-        metadata: {
-          ga: {
-            config: {
-              colorTemperatureRange: '1000,5000'
+      expect(
+        Command.convertParamsToValue(
+          params,
+          {},
+          {
+            customData: {
+              deviceType: 'SpecialColorLight',
+              colorTemperatureRange: { temperatureMinK: 1000, temperatureMaxK: 5000 }
             }
           }
-        }
-      };
-      const device = { customData: { deviceType: 'SpecialColorLight' } };
-      expect(Command.convertParamsToValue(params, item, device)).toBe('75');
-      expect(Command.convertParamsToValue(params, { state: '100,100,50' }, device)).toBe('0');
+        )
+      ).toBe('75');
+      expect(
+        Command.convertParamsToValue(
+          params,
+          { state: '100,100,50' },
+          {
+            customData: {
+              deviceType: 'SpecialColorLight'
+            }
+          }
+        )
+      ).toBe('0');
     });
 
     test('convertParamsToValue SpecialColorLight Kelvin', () => {
-      const item = {
-        metadata: {
-          ga: {
-            config: {
-              colorTemperatureRange: '1000,5000',
-              useKelvin: true
-            }
+      expect(
+        Command.convertParamsToValue(
+          params,
+          {},
+          {
+            customData: { deviceType: 'SpecialColorLight', useKelvin: true }
           }
-        }
-      };
-      const device = { customData: { deviceType: 'SpecialColorLight' } };
-      expect(Command.convertParamsToValue(params, item, device)).toBe('2000');
+        )
+      ).toBe('2000');
     });
   });
 

--- a/tests/commands/medianext.test.js
+++ b/tests/commands/medianext.test.js
@@ -5,35 +5,18 @@ describe('mediaNext Command', () => {
     expect(Command.validateParams({})).toBe(true);
   });
 
-  test('requiresItem', () => {
-    expect(Command.requiresItem()).toBe(true);
-  });
-
-  describe('getItemName', () => {
-    test('getItemName', () => {
-      const item = {
-        members: [
-          {
-            name: 'TransportItem',
-            metadata: {
-              ga: {
-                value: 'tvTransport'
-              }
-            }
-          }
-        ]
-      };
-      expect(Command.getItemName(item)).toBe('TransportItem');
-    });
-
-    test('getItemName no transport', () => {
-      const item = {
-        members: []
-      };
-      expect(() => {
-        Command.getItemName(item);
-      }).toThrow();
-    });
+  test('getItemName', () => {
+    const device = {
+      customData: {
+        members: {
+          tvTransport: 'TransportItem'
+        }
+      }
+    };
+    expect(Command.getItemName(device)).toBe('TransportItem');
+    expect(() => {
+      Command.getItemName({ customData: { members: {} } });
+    }).toThrow();
   });
 
   test('convertParamsToValue', () => {

--- a/tests/commands/mediapause.test.js
+++ b/tests/commands/mediapause.test.js
@@ -5,35 +5,18 @@ describe('mediaPause Command', () => {
     expect(Command.validateParams({})).toBe(true);
   });
 
-  test('requiresItem', () => {
-    expect(Command.requiresItem()).toBe(true);
-  });
-
-  describe('getItemName', () => {
-    test('getItemName', () => {
-      const item = {
-        members: [
-          {
-            name: 'TransportItem',
-            metadata: {
-              ga: {
-                value: 'tvTransport'
-              }
-            }
-          }
-        ]
-      };
-      expect(Command.getItemName(item)).toBe('TransportItem');
-    });
-
-    test('getItemName no transport', () => {
-      const item = {
-        members: []
-      };
-      expect(() => {
-        Command.getItemName(item);
-      }).toThrow();
-    });
+  test('getItemName', () => {
+    const device = {
+      customData: {
+        members: {
+          tvTransport: 'TransportItem'
+        }
+      }
+    };
+    expect(Command.getItemName(device)).toBe('TransportItem');
+    expect(() => {
+      Command.getItemName({ customData: { members: {} } });
+    }).toThrow();
   });
 
   test('convertParamsToValue', () => {

--- a/tests/commands/mediaprevious.test.js
+++ b/tests/commands/mediaprevious.test.js
@@ -5,35 +5,18 @@ describe('mediaPrevious Command', () => {
     expect(Command.validateParams({})).toBe(true);
   });
 
-  test('requiresItem', () => {
-    expect(Command.requiresItem()).toBe(true);
-  });
-
-  describe('getItemName', () => {
-    test('getItemName', () => {
-      const item = {
-        members: [
-          {
-            name: 'TransportItem',
-            metadata: {
-              ga: {
-                value: 'tvTransport'
-              }
-            }
-          }
-        ]
-      };
-      expect(Command.getItemName(item)).toBe('TransportItem');
-    });
-
-    test('getItemName no transport', () => {
-      const item = {
-        members: []
-      };
-      expect(() => {
-        Command.getItemName(item);
-      }).toThrow();
-    });
+  test('getItemName', () => {
+    const device = {
+      customData: {
+        members: {
+          tvTransport: 'TransportItem'
+        }
+      }
+    };
+    expect(Command.getItemName(device)).toBe('TransportItem');
+    expect(() => {
+      Command.getItemName({ customData: { members: {} } });
+    }).toThrow();
   });
 
   test('convertParamsToValue', () => {

--- a/tests/commands/mediaresume.test.js
+++ b/tests/commands/mediaresume.test.js
@@ -5,35 +5,18 @@ describe('mediaResume Command', () => {
     expect(Command.validateParams({})).toBe(true);
   });
 
-  test('requiresItem', () => {
-    expect(Command.requiresItem()).toBe(true);
-  });
-
-  describe('getItemName', () => {
-    test('getItemName', () => {
-      const item = {
-        members: [
-          {
-            name: 'TransportItem',
-            metadata: {
-              ga: {
-                value: 'tvTransport'
-              }
-            }
-          }
-        ]
-      };
-      expect(Command.getItemName(item)).toBe('TransportItem');
-    });
-
-    test('getItemName no transport', () => {
-      const item = {
-        members: []
-      };
-      expect(() => {
-        Command.getItemName(item);
-      }).toThrow();
-    });
+  test('getItemName', () => {
+    const device = {
+      customData: {
+        members: {
+          tvTransport: 'TransportItem'
+        }
+      }
+    };
+    expect(Command.getItemName(device)).toBe('TransportItem');
+    expect(() => {
+      Command.getItemName({ customData: { members: {} } });
+    }).toThrow();
   });
 
   test('convertParamsToValue', () => {

--- a/tests/commands/mute.test.js
+++ b/tests/commands/mute.test.js
@@ -6,56 +6,42 @@ describe('Mute Command', () => {
     expect(Command.validateParams({ mute: true })).toBe(true);
   });
 
-  test('requiresItem', () => {
-    expect(Command.requiresItem({})).toBe(false);
-    expect(Command.requiresItem({ customData: {} })).toBe(false);
-    expect(Command.requiresItem({ customData: { deviceType: 'TV' } })).toBe(true);
-  });
-
   describe('getItemName', () => {
     test('getItemName', () => {
-      expect(Command.getItemName({ name: 'Item' }, {})).toBe('Item');
-      expect(Command.getItemName({ name: 'Item' }, { customData: {} })).toBe('Item');
+      expect(Command.getItemName({ id: 'Item' })).toBe('Item');
+      expect(Command.getItemName({ id: 'Item', customData: {} })).toBe('Item');
     });
 
     test('getItemName TV no members', () => {
       expect(() => {
-        Command.getItemName({ name: 'Item' }, { customData: { deviceType: 'TV' } });
+        Command.getItemName({ id: 'Item', customData: { deviceType: 'TV' } });
       }).toThrow();
     });
 
     test('getItemName TV mute', () => {
-      const item = {
-        name: 'Item',
-        members: [
-          {
-            name: 'MuteItem',
-            metadata: {
-              ga: {
-                value: 'tvMute'
-              }
-            }
+      const device = {
+        id: 'Item',
+        customData: {
+          deviceType: 'TV',
+          members: {
+            tvMute: 'MuteItem'
           }
-        ]
+        }
       };
-      expect(Command.getItemName(item, { customData: { deviceType: 'TV' } })).toBe('MuteItem');
+      expect(Command.getItemName(device)).toBe('MuteItem');
     });
 
     test('getItemName TV volume', () => {
-      const item = {
-        name: 'Item',
-        members: [
-          {
-            name: 'VolumeItem',
-            metadata: {
-              ga: {
-                value: 'tvVolume'
-              }
-            }
+      const device = {
+        id: 'Item',
+        customData: {
+          deviceType: 'TV',
+          members: {
+            tvVolume: 'VolumeItem'
           }
-        ]
+        }
       };
-      expect(Command.getItemName(item, { customData: { deviceType: 'TV' } })).toBe('VolumeItem');
+      expect(Command.getItemName(device)).toBe('VolumeItem');
     });
   });
 
@@ -80,33 +66,19 @@ describe('Mute Command', () => {
     });
 
     test('convertParamsToValue TV mute', () => {
-      const item = {
-        members: [
-          {
-            metadata: {
-              ga: {
-                value: 'tvMute'
-              }
-            }
-          }
-        ]
-      };
-      expect(Command.convertParamsToValue({ mute: true }, item, { customData: { deviceType: 'TV' } })).toBe('ON');
+      expect(
+        Command.convertParamsToValue({ mute: true }, undefined, {
+          customData: { deviceType: 'TV', members: { tvMute: 'MuteItem' } }
+        })
+      ).toBe('ON');
     });
 
     test('convertParamsToValue TV volume', () => {
-      const item = {
-        members: [
-          {
-            metadata: {
-              ga: {
-                value: 'tvVolume'
-              }
-            }
-          }
-        ]
-      };
-      expect(Command.convertParamsToValue({ mute: true }, item, { customData: { deviceType: 'TV' } })).toBe('0');
+      expect(
+        Command.convertParamsToValue({ mute: true }, undefined, {
+          customData: { deviceType: 'TV', members: { tvVolume: 'VolumeItem' } }
+        })
+      ).toBe('0');
     });
   });
 

--- a/tests/commands/onoff.test.js
+++ b/tests/commands/onoff.test.js
@@ -6,54 +6,48 @@ describe('OnOff Command', () => {
     expect(Command.validateParams({ on: true })).toBe(true);
   });
 
-  test('requiresItem', () => {
-    expect(Command.requiresItem({})).toBe(false);
-    expect(Command.requiresItem({ customData: { deviceType: 'SpecialColorLight' } })).toBe(true);
-    expect(Command.requiresItem({ customData: { deviceType: 'TV' } })).toBe(true);
-  });
-
   describe('getItemName', () => {
     test('getItemName', () => {
-      expect(Command.getItemName({ name: 'Item' }, {})).toBe('Item');
-      expect(Command.getItemName({ name: 'Item' }, { customData: {} })).toBe('Item');
+      expect(Command.getItemName({ id: 'Item' })).toBe('Item');
+      expect(Command.getItemName({ id: 'Item', customData: {} })).toBe('Item');
     });
 
     test('getItemName SpecialColorLight', () => {
       expect(() => {
-        Command.getItemName({ name: 'Item' }, { customData: { deviceType: 'SpecialColorLight' } });
+        Command.getItemName({ id: 'Item', customData: { deviceType: 'SpecialColorLight' } });
       }).toThrow();
-      const item = {
-        members: [
-          {
-            name: 'BrightnessItem',
-            metadata: {
-              ga: {
-                value: 'lightBrightness'
-              }
-            }
+    });
+
+    test('getItemName SpecialColorLight', () => {
+      expect(() => {
+        Command.getItemName({ id: 'Item', customData: { deviceType: 'SpecialColorLight' } });
+      }).toThrow();
+      const device = {
+        id: 'Item',
+        customData: {
+          deviceType: 'SpecialColorLight',
+          members: {
+            lightBrightness: 'BrightnessItem'
           }
-        ]
+        }
       };
-      expect(Command.getItemName(item, { customData: { deviceType: 'SpecialColorLight' } })).toBe('BrightnessItem');
+      expect(Command.getItemName(device)).toBe('BrightnessItem');
     });
 
     test('getItemName TV', () => {
       expect(() => {
-        Command.getItemName({ name: 'Item' }, { customData: { deviceType: 'TV' } });
+        Command.getItemName({ name: 'Item', customData: { deviceType: 'TV' } });
       }).toThrow();
-      const item = {
-        members: [
-          {
-            name: 'PowerItem',
-            metadata: {
-              ga: {
-                value: 'tvPower'
-              }
-            }
+      const device = {
+        id: 'Item',
+        customData: {
+          deviceType: 'TV',
+          members: {
+            tvPower: 'PowerItem'
           }
-        ]
+        }
       };
-      expect(Command.getItemName(item, { customData: { deviceType: 'TV' } })).toBe('PowerItem');
+      expect(Command.getItemName(device)).toBe('PowerItem');
     });
   });
 

--- a/tests/commands/selectchannel.test.js
+++ b/tests/commands/selectchannel.test.js
@@ -14,21 +14,16 @@ describe('selectChannel Command', () => {
 
   test('getItemName', () => {
     expect(() => {
-      Command.getItemName({ name: 'Item' });
+      Command.getItemName({ id: 'Item' });
     }).toThrow();
-    const item = {
-      members: [
-        {
-          name: 'ChannelItem',
-          metadata: {
-            ga: {
-              value: 'tvChannel'
-            }
-          }
+    const device = {
+      customData: {
+        members: {
+          tvChannel: 'ChannelItem'
         }
-      ]
+      }
     };
-    expect(Command.getItemName(item)).toBe('ChannelItem');
+    expect(Command.getItemName(device)).toBe('ChannelItem');
   });
 
   test('convertParamsToValue', () => {

--- a/tests/commands/setinput.test.js
+++ b/tests/commands/setinput.test.js
@@ -8,27 +8,18 @@ describe('SetInput Command', () => {
     expect(Command.validateParams(params)).toBe(true);
   });
 
-  test('requiresItem', () => {
-    expect(Command.requiresItem()).toBe(true);
-  });
-
   test('getItemName', () => {
     expect(() => {
-      Command.getItemName({ name: 'Item' });
+      Command.getItemName({ id: 'Item' });
     }).toThrow();
-    const item = {
-      members: [
-        {
-          name: 'InputItem',
-          metadata: {
-            ga: {
-              value: 'tvInput'
-            }
-          }
+    const device = {
+      customData: {
+        members: {
+          tvInput: 'InputItem'
         }
-      ]
+      }
     };
-    expect(Command.getItemName(item)).toBe('InputItem');
+    expect(Command.getItemName(device)).toBe('InputItem');
   });
 
   test('convertParamsToValue', () => {

--- a/tests/commands/setvolume.test.js
+++ b/tests/commands/setvolume.test.js
@@ -8,34 +8,25 @@ describe('setVolume Command', () => {
     expect(Command.validateParams(params)).toBe(true);
   });
 
-  test('requiresItem', () => {
-    expect(Command.requiresItem({})).toBe(false);
-    expect(Command.requiresItem({ customData: { deviceType: 'TV' } })).toBe(true);
-  });
-
   describe('getItemName', () => {
     test('getItemName', () => {
-      expect(Command.getItemName({ name: 'Item' }, {})).toBe('Item');
-      expect(Command.getItemName({ name: 'Item' }, { customData: {} })).toBe('Item');
+      expect(Command.getItemName({ id: 'Item' })).toBe('Item');
+      expect(Command.getItemName({ id: 'Item', customData: {} })).toBe('Item');
     });
 
     test('getItemName TV', () => {
       expect(() => {
-        Command.getItemName({ name: 'Item' }, { customData: { deviceType: 'TV' } });
+        Command.getItemName({ id: 'Item', customData: { deviceType: 'TV' } });
       }).toThrow();
-      const item = {
-        members: [
-          {
-            name: 'VolumeItem',
-            metadata: {
-              ga: {
-                value: 'tvVolume'
-              }
-            }
+      const device = {
+        customData: {
+          deviceType: 'TV',
+          members: {
+            tvVolume: 'VolumeItem'
           }
-        ]
+        }
       };
-      expect(Command.getItemName(item, { customData: { deviceType: 'TV' } })).toBe('VolumeItem');
+      expect(Command.getItemName(device)).toBe('VolumeItem');
     });
   });
 

--- a/tests/commands/thermostatsetmode.test.js
+++ b/tests/commands/thermostatsetmode.test.js
@@ -14,21 +14,16 @@ describe('ThermostatSetMode Command', () => {
 
   test('getItemName', () => {
     expect(() => {
-      Command.getItemName({ name: 'Item' });
+      Command.getItemName({ id: 'Item' });
     }).toThrow();
-    const item = {
-      members: [
-        {
-          name: 'ModeItem',
-          metadata: {
-            ga: {
-              value: 'thermostatMode'
-            }
-          }
+    const device = {
+      customData: {
+        members: {
+          thermostatMode: 'ModeItem'
         }
-      ]
+      }
     };
-    expect(Command.getItemName(item)).toBe('ModeItem');
+    expect(Command.getItemName(device)).toBe('ModeItem');
   });
 
   test('convertParamsToValue', () => {

--- a/tests/commands/thermostattemperaturesetpoint.test.js
+++ b/tests/commands/thermostattemperaturesetpoint.test.js
@@ -14,21 +14,16 @@ describe('ThermostatTemperatureSetpoint Command', () => {
 
   test('getItemName', () => {
     expect(() => {
-      Command.getItemName({ name: 'Item' });
+      Command.getItemName({ id: 'Item' });
     }).toThrow();
-    const item = {
-      members: [
-        {
-          name: 'SetpointItem',
-          metadata: {
-            ga: {
-              value: 'thermostatTemperatureSetpoint'
-            }
-          }
+    const device = {
+      customData: {
+        members: {
+          thermostatTemperatureSetpoint: 'SetpointItem'
         }
-      ]
+      }
     };
-    expect(Command.getItemName(item)).toBe('SetpointItem');
+    expect(Command.getItemName(device)).toBe('SetpointItem');
   });
 
   test('convertParamsToValue', () => {

--- a/tests/commands/thermostattemperaturesetpointhigh.test.js
+++ b/tests/commands/thermostattemperaturesetpointhigh.test.js
@@ -14,21 +14,16 @@ describe('ThermostatTemperatureSetpointHigh Command', () => {
 
   test('getItemName', () => {
     expect(() => {
-      Command.getItemName({ name: 'Item' });
+      Command.getItemName({ id: 'Item' });
     }).toThrow();
-    const item = {
-      members: [
-        {
-          name: 'SetpointItem',
-          metadata: {
-            ga: {
-              value: 'thermostatTemperatureSetpointHigh'
-            }
-          }
+    const device = {
+      customData: {
+        members: {
+          thermostatTemperatureSetpointHigh: 'SetpointItem'
         }
-      ]
+      }
     };
-    expect(Command.getItemName(item)).toBe('SetpointItem');
+    expect(Command.getItemName(device)).toBe('SetpointItem');
   });
 
   test('convertParamsToValue', () => {

--- a/tests/commands/thermostattemperaturesetpointlow.test.js
+++ b/tests/commands/thermostattemperaturesetpointlow.test.js
@@ -14,21 +14,16 @@ describe('ThermostatTemperatureSetpointLow Command', () => {
 
   test('getItemName', () => {
     expect(() => {
-      Command.getItemName({ name: 'Item' });
+      Command.getItemName({ id: 'Item' });
     }).toThrow();
-    const item = {
-      members: [
-        {
-          name: 'SetpointItem',
-          metadata: {
-            ga: {
-              value: 'thermostatTemperatureSetpointLow'
-            }
-          }
+    const device = {
+      customData: {
+        members: {
+          thermostatTemperatureSetpointLow: 'SetpointItem'
         }
-      ]
+      }
     };
-    expect(Command.getItemName(item)).toBe('SetpointItem');
+    expect(Command.getItemName(device)).toBe('SetpointItem');
   });
 
   test('convertParamsToValue', () => {

--- a/tests/commands/volumerelative.test.js
+++ b/tests/commands/volumerelative.test.js
@@ -14,27 +14,23 @@ describe('volumeRelative Command', () => {
 
   describe('getItemName', () => {
     test('getItemName', () => {
-      expect(Command.getItemName({ name: 'Item' }, {})).toBe('Item');
-      expect(Command.getItemName({ name: 'Item' }, { customData: {} })).toBe('Item');
+      expect(Command.getItemName({ id: 'Item' })).toBe('Item');
+      expect(Command.getItemName({ id: 'Item', customData: {} })).toBe('Item');
     });
 
     test('getItemName TV', () => {
       expect(() => {
-        Command.getItemName({ name: 'Item' }, { customData: { deviceType: 'TV' } });
+        Command.getItemName({ id: 'Item', customData: { deviceType: 'TV' } });
       }).toThrow();
-      const item = {
-        members: [
-          {
-            name: 'VolumeItem',
-            metadata: {
-              ga: {
-                value: 'tvVolume'
-              }
-            }
+      const device = {
+        customData: {
+          deviceType: 'TV',
+          members: {
+            tvVolume: 'VolumeItem'
           }
-        ]
+        }
       };
-      expect(Command.getItemName(item, { customData: { deviceType: 'TV' } })).toBe('VolumeItem');
+      expect(Command.getItemName(device)).toBe('VolumeItem');
     });
   });
 

--- a/tests/devices/camera.test.js
+++ b/tests/devices/camera.test.js
@@ -1,9 +1,9 @@
 const Device = require('../../functions/devices/camera.js');
 
 describe('Camera Device', () => {
-  test('isCompatible', () => {
+  test('matchesDeviceType', () => {
     expect(
-      Device.isCompatible({
+      Device.matchesDeviceType({
         metadata: {
           ga: {
             value: 'CAMERA'

--- a/tests/devices/colorlight.test.js
+++ b/tests/devices/colorlight.test.js
@@ -1,9 +1,9 @@
 const Device = require('../../functions/devices/colorlight.js');
 
 describe('ColorLight Device', () => {
-  test('isCompatible', () => {
+  test('matchesDeviceType', () => {
     expect(
-      Device.isCompatible({
+      Device.matchesDeviceType({
         metadata: {
           ga: {
             value: 'LIGHT'

--- a/tests/devices/dimmablelight.test.js
+++ b/tests/devices/dimmablelight.test.js
@@ -1,9 +1,9 @@
 const Device = require('../../functions/devices/dimmablelight.js');
 
 describe('DimmableLight Device', () => {
-  test('isCompatible', () => {
+  test('matchesDeviceType', () => {
     expect(
-      Device.isCompatible({
+      Device.matchesDeviceType({
         metadata: {
           ga: {
             value: 'LIGHT'

--- a/tests/devices/fan.test.js
+++ b/tests/devices/fan.test.js
@@ -1,9 +1,9 @@
 const Device = require('../../functions/devices/fan.js');
 
 describe('Fan Device', () => {
-  test('isCompatible', () => {
+  test('matchesDeviceType', () => {
     expect(
-      Device.isCompatible({
+      Device.matchesDeviceType({
         metadata: {
           ga: {
             value: 'FAN'

--- a/tests/devices/lock.test.js
+++ b/tests/devices/lock.test.js
@@ -1,9 +1,9 @@
 const Device = require('../../functions/devices/lock.js');
 
 describe('Lock Device', () => {
-  test('isCompatible', () => {
+  test('matchesDeviceType', () => {
     expect(
-      Device.isCompatible({
+      Device.matchesDeviceType({
         metadata: {
           ga: {
             value: 'LOCK'

--- a/tests/devices/scene.test.js
+++ b/tests/devices/scene.test.js
@@ -1,9 +1,9 @@
 const Device = require('../../functions/devices/scene.js');
 
 describe('Scene Device', () => {
-  test('isCompatible', () => {
+  test('matchesDeviceType', () => {
     expect(
-      Device.isCompatible({
+      Device.matchesDeviceType({
         metadata: {
           ga: {
             value: 'SCENE'

--- a/tests/devices/securitysystem.test.js
+++ b/tests/devices/securitysystem.test.js
@@ -1,9 +1,9 @@
 const Device = require('../../functions/devices/securitysystem.js');
 
 describe('SecuritySystem Device', () => {
-  test('isCompatible', () => {
+  test('matchesDeviceType', () => {
     expect(
-      Device.isCompatible({
+      Device.matchesDeviceType({
         metadata: {
           ga: {
             value: 'SECURITYSYSTEM'

--- a/tests/devices/sensor.test.js
+++ b/tests/devices/sensor.test.js
@@ -1,47 +1,48 @@
 const Device = require('../../functions/devices/sensor.js');
 
 describe('Sensor Device', () => {
-  test('isCompatible', () => {
+  test('matchesDeviceType', () => {
     expect(
-      Device.isCompatible({
+      Device.matchesDeviceType({
         metadata: {
           ga: {
             value: 'SENSOR'
           }
         }
       })
-    ).toBe(true);
-  });
-
-  describe('matchesItemType', () => {
-    describe('matchesItemType numeric', () => {
-      const item = {
+    ).toBe(false);
+    expect(
+      Device.matchesDeviceType({
         metadata: {
           ga: {
+            value: 'SENSOR',
             config: {
               sensorName: 'Sensor',
               valueUnit: 'PERCENT'
             }
           }
         }
-      };
-      expect(Device.matchesItemType(item)).toBe(true);
-      expect(Device.matchesItemType({ type: 'Number' })).toBe(false);
-    });
-
-    describe('matchesItemType descriptive', () => {
-      const item = {
+      })
+    ).toBe(true);
+    expect(
+      Device.matchesDeviceType({
         metadata: {
           ga: {
+            value: 'SENSOR',
             config: {
               sensorName: 'Sensor',
               states: '50=good,100=bad'
             }
           }
         }
-      };
-      expect(Device.matchesItemType(item)).toBe(true);
-    });
+      })
+    ).toBe(true);
+  });
+
+  test('matchesItemType', () => {
+    expect(Device.matchesItemType({ type: 'Group' })).toBe(false);
+    expect(Device.matchesItemType({ type: 'Group', groupType: 'String' })).toBe(true);
+    expect(Device.matchesItemType({ type: 'Number' })).toBe(true);
   });
 
   describe('getAttributes', () => {
@@ -53,7 +54,7 @@ describe('Sensor Device', () => {
           }
         }
       };
-      expect(Device.getAttributes(item)).toStrictEqual({ sensorStatesSupported: {} });
+      expect(Device.getAttributes(item)).toStrictEqual({});
     });
 
     test('getAttributes states', () => {

--- a/tests/devices/simplelight.test.js
+++ b/tests/devices/simplelight.test.js
@@ -1,9 +1,9 @@
 const Device = require('../../functions/devices/simplelight.js');
 
 describe('SimpleLight Device', () => {
-  test('isCompatible', () => {
+  test('matchesDeviceType', () => {
     expect(
-      Device.isCompatible({
+      Device.matchesDeviceType({
         metadata: {
           ga: {
             value: 'LIGHT'

--- a/tests/devices/speaker.test.js
+++ b/tests/devices/speaker.test.js
@@ -1,9 +1,9 @@
 const Device = require('../../functions/devices/speaker.js');
 
 describe('Speaker Device', () => {
-  test('isCompatible', () => {
+  test('matchesDeviceType', () => {
     expect(
-      Device.isCompatible({
+      Device.matchesDeviceType({
         metadata: {
           ga: {
             value: 'SPEAKER'

--- a/tests/devices/specialcolorlight.test.js
+++ b/tests/devices/specialcolorlight.test.js
@@ -1,21 +1,8 @@
 const Device = require('../../functions/devices/specialcolorlight.js');
 
 describe('SpecialColorLight Device', () => {
-  test('isCompatible', () => {
-    expect(
-      Device.isCompatible({
-        metadata: {
-          ga: {
-            value: 'LIGHT'
-          }
-        }
-      })
-    ).toBe(true);
-  });
-
-  test('matchesItemType', () => {
+  test('matchesDeviceType', () => {
     const item = {
-      type: 'Group',
       metadata: {
         ga: {
           value: 'LIGHT',
@@ -42,7 +29,6 @@ describe('SpecialColorLight Device', () => {
       ]
     };
     const item2 = {
-      type: 'Group',
       metadata: {
         ga: {
           value: 'LIGHT'
@@ -66,7 +52,6 @@ describe('SpecialColorLight Device', () => {
       ]
     };
     const item3 = {
-      type: 'Group',
       metadata: {
         ga: {
           value: 'LIGHT',
@@ -92,9 +77,13 @@ describe('SpecialColorLight Device', () => {
         }
       ]
     };
-    expect(Device.matchesItemType(item)).toBe(true);
-    expect(Device.matchesItemType(item2)).toBe(false);
-    expect(Device.matchesItemType(item3)).toBe(true);
+    expect(Device.matchesDeviceType(item)).toBe(true);
+    expect(Device.matchesDeviceType(item2)).toBe(false);
+    expect(Device.matchesDeviceType(item3)).toBe(true);
+  });
+
+  test('matchesItemType', () => {
+    expect(Device.matchesItemType({ type: 'Group' })).toBe(true);
     expect(Device.matchesItemType({ type: 'Color' })).toBe(false);
     expect(Device.matchesItemType({ type: 'Group', groupType: 'Color' })).toBe(false);
     expect(Device.matchesItemType({ type: 'Group', groupType: 'Dimmer' })).toBe(false);
@@ -130,6 +119,31 @@ describe('SpecialColorLight Device', () => {
         }
       };
       expect(Device.getAttributes(item1)).toStrictEqual({});
+    });
+  });
+
+  test('getMetadata', () => {
+    const item = {
+      name: 'LightItem',
+      type: 'Group',
+      metadata: {
+        ga: {
+          config: {
+            colorTemperatureRange: '1000,2000',
+            useKelvin: true
+          }
+        }
+      }
+    };
+    expect(Device.getMetadata(item).customData).toStrictEqual({
+      colorTemperatureRange: {
+        temperatureMaxK: 2000,
+        temperatureMinK: 1000
+      },
+      deviceType: 'SpecialColorLight',
+      itemType: 'Group',
+      members: {},
+      useKelvin: true
     });
   });
 

--- a/tests/devices/switch.test.js
+++ b/tests/devices/switch.test.js
@@ -1,9 +1,9 @@
 const Device = require('../../functions/devices/switch.js');
 
 describe('Switch Device', () => {
-  test('isCompatible', () => {
+  test('matchesDeviceType', () => {
     expect(
-      Device.isCompatible({
+      Device.matchesDeviceType({
         metadata: {
           ga: {
             value: 'SWITCH'

--- a/tests/devices/temperaturesensor.test.js
+++ b/tests/devices/temperaturesensor.test.js
@@ -1,9 +1,9 @@
 const Device = require('../../functions/devices/temperaturesensor.js');
 
 describe('TemperatureSensor Device', () => {
-  test('isCompatible', () => {
+  test('matchesDeviceType', () => {
     expect(
-      Device.isCompatible({
+      Device.matchesDeviceType({
         metadata: {
           ga: {
             value: 'temperaturesensor'

--- a/tests/devices/thermostat.test.js
+++ b/tests/devices/thermostat.test.js
@@ -1,33 +1,39 @@
 const Device = require('../../functions/devices/thermostat.js');
 
 describe('Thermostat Device', () => {
-  test('isCompatible', () => {
+  test('matchesDeviceType', () => {
     expect(
-      Device.isCompatible({
+      Device.matchesDeviceType({
         metadata: {
           ga: {
             value: 'THERMOSTAT'
           }
         }
       })
+    ).toBe(false);
+    expect(
+      Device.matchesDeviceType({
+        metadata: {
+          ga: {
+            value: 'THERMOSTAT'
+          }
+        },
+        members: [
+          {
+            metadata: {
+              ga: {
+                value: 'thermostatTemperatureAmbient'
+              }
+            }
+          }
+        ]
+      })
     ).toBe(true);
   });
 
   test('matchesItemType', () => {
-    const item = {
-      type: 'Group',
-      members: [
-        {
-          metadata: {
-            ga: {
-              value: 'thermostatTemperatureAmbient'
-            }
-          }
-        }
-      ]
-    };
-    expect(Device.matchesItemType(item)).toBe(true);
-    expect(Device.matchesItemType({ type: 'Group' })).toBe(false);
+    expect(Device.matchesItemType({ type: 'Number' })).toBe(false);
+    expect(Device.matchesItemType({ type: 'Group' })).toBe(true);
   });
 
   describe('useFahrenheit', () => {

--- a/tests/devices/tv.test.js
+++ b/tests/devices/tv.test.js
@@ -1,33 +1,39 @@
 const Device = require('../../functions/devices/tv.js');
 
 describe('TV Device', () => {
-  test('isCompatible', () => {
+  test('matchesDeviceType', () => {
     expect(
-      Device.isCompatible({
+      Device.matchesDeviceType({
         metadata: {
           ga: {
             value: 'TV'
           }
         }
       })
+    ).toBe(false);
+    expect(
+      Device.matchesDeviceType({
+        metadata: {
+          ga: {
+            value: 'TV'
+          }
+        },
+        members: [
+          {
+            metadata: {
+              ga: {
+                value: 'tvPower'
+              }
+            }
+          }
+        ]
+      })
     ).toBe(true);
   });
 
   test('matchesItemType', () => {
-    const item = {
-      type: 'Group',
-      members: [
-        {
-          metadata: {
-            ga: {
-              value: 'tvPower'
-            }
-          }
-        }
-      ]
-    };
-    expect(Device.matchesItemType(item)).toBe(true);
-    expect(Device.matchesItemType({ type: 'Group' })).toBe(false);
+    expect(Device.matchesItemType({ type: 'Switch' })).toBe(false);
+    expect(Device.matchesItemType({ type: 'Group' })).toBe(true);
   });
 
   describe('getTraits', () => {

--- a/tests/devices/valve.test.js
+++ b/tests/devices/valve.test.js
@@ -1,9 +1,9 @@
 const Device = require('../../functions/devices/valve.js');
 
 describe('Valve Device', () => {
-  test('isCompatible', () => {
+  test('matchesDeviceType', () => {
     expect(
-      Device.isCompatible({
+      Device.matchesDeviceType({
         metadata: {
           ga: {
             value: 'VALVE'

--- a/tests/openhab.test.js
+++ b/tests/openhab.test.js
@@ -8,12 +8,10 @@ describe('OpenHAB', () => {
     expect(command.name).toBe('OnOff');
   });
 
-  describe('getDeviceForItem', () => {
-    test('getDeviceForItem switch', () => {
-      const device = OpenHAB.getDeviceForItem({ type: 'Switch', metadata: { ga: { value: 'Switch' } } });
-      expect(device).not.toBeUndefined();
-      expect(device.name).toBe('Switch');
-    });
+  test('getDeviceForItem switch', () => {
+    const device = OpenHAB.getDeviceForItem({ type: 'Switch', metadata: { ga: { value: 'Switch' } } });
+    expect(device).not.toBeUndefined();
+    expect(device.name).toBe('Switch');
   });
 
   test('setTokenFromHeader', () => {
@@ -192,7 +190,11 @@ describe('OpenHAB', () => {
             },
             customData: {
               deviceType: 'TV',
-              itemType: 'Group'
+              itemType: 'Group',
+              members: {
+                tvMute: 'TVMute',
+                tvPower: 'TVPower'
+              }
             },
             deviceInfo: {
               manufacturer: 'openHAB',
@@ -628,7 +630,12 @@ describe('OpenHAB', () => {
           devices: [
             {
               id: 'TestItem',
-              customData: {}
+              customData: {
+                members: {
+                  thermostatTemperatureSetpointHigh: 'Test1',
+                  thermostatTemperatureSetpointLow: 'Test2'
+                }
+              }
             }
           ],
           execution: [


### PR DESCRIPTION
Changes:
- item names for group members are stored in customData to save a query request to openHAB when executing commands
- for commands that need the current state the query request is still needed (thermostat commands or relative volume)
- also some other configuration options are stored in customData
- there is no change on the user's side required but they will need to do a SYNC

Possible issues:
- As customData is limited to 512 bytes it could be an issue to store very long item names e.g. for devices with a lot of members like thermostat (ref. https://developers.google.com/assistant/smarthome/reference/intent/sync)