### PR TITLE
Catch JSON parse error in apihandler

### DIFF
--- a/functions/apihandler.js
+++ b/functions/apihandler.js
@@ -91,14 +91,21 @@ class ApiHandler {
         }
 
         response.setEncoding('utf8');
-        let body = '';
+        let data = '';
 
-        response.on('data', (data) => {
-          body += data.toString('utf-8');
+        response.on('data', (chunk) => {
+          data += chunk;
         });
 
         response.on('end', () => {
-          resolve(JSON.parse(body));
+          try {
+            resolve(JSON.parse(data));
+          } catch (e) {
+            reject({
+              statusCode: 415,
+              message: 'getItem - JSON parse failed for path: ' + options.path + ' - ' + e.toString()
+            });
+          }
         });
       });
       req.on('error', reject);

--- a/tests/apihandler.test.js
+++ b/tests/apihandler.test.js
@@ -101,6 +101,23 @@ describe('ApiHandler', () => {
       expect(result).toStrictEqual({ name: 'TestItem' });
       expect(scope.isDone()).toBe(true);
     });
+
+    test('getItem failed bad JSON', async () => {
+      const scope = nock('https://example.org').get('/items/TestItem?metadata=ga,synonyms').reply(200, 'INVALID');
+      let error = {};
+      try {
+        await apiHandler.getItem('TestItem');
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toStrictEqual({
+        message:
+          // eslint-disable-next-line max-len
+          'getItem - JSON parse failed for path: /items/TestItem?metadata=ga,synonyms - SyntaxError: Unexpected token I in JSON at position 0',
+        statusCode: 415
+      });
+      expect(scope.isDone()).toBe(true);
+    });
   });
 
   describe('getItems', () => {


### PR DESCRIPTION
As seen in the logs of the running cloud functions, there seem to be cases where invalid JSON is responded from openHAB(cloud).

To avoid exceptions, this is now caught.