### PR TITLE
Add Charger device and Charge command

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -310,6 +310,29 @@ Rollershutter { ga="Shutter" }
 Rollershutter { ga="Window" }
 ```
 
+#### `Charger`
+
+| | |
+|---|---|
+| **Device Type** | [Charger](https://developers.google.com/assistant/smarthome/guides/charger) |
+| **Supported Traits** | [EnergyStorage](https://developers.google.com/assistant/smarthome/traits/energystorage) |
+| **Supported Items** | Group as `Charger` with the following optional members: Switch as `chargerCharging`, Switch as `chargerPluggedIn`, Number or Dimmer as `chargerCapacityRemaining`, Number or Dimmer as `chargerCapacityUntilFull` |
+| **Configuration** | (optional) `isRechargeable=true/false`<br>(optional) `unit="PERCENTAGE"` |
+
+The configuration option `unit` supports the following values: `PERCENTAGE` (default), `SECONDS`, `MILES`, `KILOMETERS`, `KILOWATT_HOURS`
+
+The setting `isRechargeable` defaults to `false` if not explicitly set to `true`.
+
+If no `chargerCharging` item is specified, the device will only support queries.
+
+```shell
+Group  chargerGroup { ga="Charger" [ isRechargeable=true, unit="KILOWATT_HOURS" ] }
+Switch chargingItem         (chargerGroup) { ga="chargerCharging" }
+Switch pluggedInItem        (chargerGroup) { ga="chargerPluggedIn" }
+Number capacityRemainItem   (chargerGroup) { ga="chargerCapacityRemaining" }
+Number capacityFullItem     (chargerGroup) { ga="chargerCapacityUntilFull" }
+```
+
 #### `TemperatureSensor`
 
 | | |

--- a/functions/commands/charge.js
+++ b/functions/commands/charge.js
@@ -1,0 +1,40 @@
+const DefaultCommand = require('./default.js');
+const Charger = require('../devices/charger.js');
+
+class Charge extends DefaultCommand {
+  static get type() {
+    return 'action.devices.commands.Charge';
+  }
+
+  static validateParams(params) {
+    return 'charge' in params && typeof params.charge === 'boolean';
+  }
+
+  static requiresItem() {
+    return true;
+  }
+
+  static getItemName(item) {
+    const members = Charger.getMembers(item);
+    if ('chargerCharging' in members) {
+      return members.chargerCharging.name;
+    }
+    throw { statusCode: 400 };
+  }
+
+  static convertParamsToValue(params, _, device) {
+    let charge = params.charge;
+    if (this.isInverted(device) === true) {
+      charge = !charge;
+    }
+    return charge ? 'ON' : 'OFF';
+  }
+
+  static getResponseStates(params, item) {
+    const states = Charger.getState(item);
+    states.isCharging = params.charge;
+    return states;
+  }
+}
+
+module.exports = Charge;

--- a/functions/devices/charger.js
+++ b/functions/devices/charger.js
@@ -17,7 +17,7 @@ class Charger extends DefaultDevice {
     const config = this.getConfig(item);
     const members = this.getMembers(item);
     const attributes = {
-      isRechargeable: config.isRechargeable || false,
+      isRechargeable: config.isRechargeable === true,
       queryOnlyEnergyStorage: !('chargerCharging' in members)
     };
     return attributes;

--- a/functions/devices/charger.js
+++ b/functions/devices/charger.js
@@ -1,0 +1,99 @@
+const DefaultDevice = require('./default.js');
+
+class Charger extends DefaultDevice {
+  static get type() {
+    return 'action.devices.types.CHARGER';
+  }
+
+  static getTraits() {
+    return ['action.devices.traits.EnergyStorage'];
+  }
+
+  static matchesItemType(item) {
+    return item.type === 'Group' && Object.keys(this.getMembers(item)).length > 0;
+  }
+
+  static getAttributes(item) {
+    const config = this.getConfig(item);
+    const members = this.getMembers(item);
+    const attributes = {
+      isRechargeable: config.isRechargeable || false,
+      queryOnlyEnergyStorage: !('chargerCharging' in members)
+    };
+    return attributes;
+  }
+
+  static getState(item) {
+    const state = {};
+    const config = this.getConfig(item);
+    const members = this.getMembers(item);
+    for (const member in members) {
+      switch (member) {
+        case 'chargerCharging':
+          state.isCharging = members[member].state === 'ON';
+          break;
+        case 'chargerPluggedIn':
+          state.isPluggedIn = members[member].state === 'ON';
+          break;
+        case 'chargerCapacityRemaining': {
+          if (!config.unit || config.unit === 'PERCENTAGE') {
+            let descCapacity = 'UNKNOWN';
+            const capacity = Number(members[member].state);
+            if (capacity <= 10) {
+              descCapacity = 'CRITICALLY_LOW';
+            } else if (capacity <= 40) {
+              descCapacity = 'LOW';
+            } else if (capacity <= 75) {
+              descCapacity = 'MEDIUM';
+            } else if (capacity < 100) {
+              descCapacity = 'HIGH';
+            } else {
+              descCapacity = 'FULL';
+            }
+            state.descriptiveCapacityRemaining = descCapacity;
+          }
+          state.capacityRemaining = [
+            {
+              unit: config.unit || 'PERCENTAGE',
+              rawValue: Number(members[member].state)
+            }
+          ];
+          break;
+        }
+        case 'chargerCapacityUntilFull': {
+          state.capacityUntilFull = [
+            {
+              unit: config.unit || 'PERCENTAGE',
+              rawValue: Number(members[member].state)
+            }
+          ];
+          break;
+        }
+      }
+    }
+    return state;
+  }
+
+  static getMembers(item) {
+    const supportedMembers = [
+      'chargerCharging',
+      'chargerPluggedIn',
+      'chargerCapacityRemaining',
+      'chargerCapacityUntilFull'
+    ];
+    const members = {};
+    if (item.members && item.members.length) {
+      item.members.forEach((member) => {
+        if (member.metadata && member.metadata.ga) {
+          const memberType = supportedMembers.find((m) => member.metadata.ga.value.toLowerCase() === m.toLowerCase());
+          if (memberType) {
+            members[memberType] = { name: member.name, state: member.state };
+          }
+        }
+      });
+    }
+    return members;
+  }
+}
+
+module.exports = Charger;

--- a/tests/commands/charge.test.js
+++ b/tests/commands/charge.test.js
@@ -44,7 +44,6 @@ describe('Charge Command', () => {
     const item = {
       members: [
         {
-          name: 'ChargingItem',
           metadata: {
             ga: {
               value: 'chargerCharging'
@@ -53,7 +52,6 @@ describe('Charge Command', () => {
           state: 'OFF'
         },
         {
-          name: 'ChargingItem',
           metadata: {
             ga: {
               value: 'chargerCapacityRemaining'

--- a/tests/commands/charge.test.js
+++ b/tests/commands/charge.test.js
@@ -1,0 +1,87 @@
+const Command = require('../../functions/commands/charge.js');
+
+describe('Charge Command', () => {
+  test('validateParams', () => {
+    expect(Command.validateParams({})).toBe(false);
+    expect(Command.validateParams({ charge: true })).toBe(true);
+  });
+
+  test('requiresItem', () => {
+    expect(Command.requiresItem()).toBe(true);
+  });
+
+  test('getItemName', () => {
+    expect(() => {
+      Command.getItemName({ name: 'Item' });
+    }).toThrow();
+
+    const item = {
+      members: [
+        {
+          name: 'ChargingItem',
+          metadata: {
+            ga: {
+              value: 'chargerCharging'
+            }
+          }
+        }
+      ]
+    };
+    expect(Command.getItemName(item)).toBe('ChargingItem');
+  });
+
+  describe('convertParamsToValue', () => {
+    test('convertParamsToValue', () => {
+      expect(Command.convertParamsToValue({ charge: true }, {}, {})).toBe('ON');
+    });
+
+    test('convertParamsToValue inverted', () => {
+      expect(Command.convertParamsToValue({ charge: true }, {}, { customData: { inverted: true } })).toBe('OFF');
+    });
+  });
+
+  test('getResponseStates', () => {
+    const item = {
+      members: [
+        {
+          name: 'ChargingItem',
+          metadata: {
+            ga: {
+              value: 'chargerCharging'
+            }
+          },
+          state: 'OFF'
+        },
+        {
+          name: 'ChargingItem',
+          metadata: {
+            ga: {
+              value: 'chargerCapacityRemaining'
+            }
+          },
+          state: '50'
+        }
+      ]
+    };
+    expect(Command.getResponseStates({ charge: true }, item)).toStrictEqual({
+      isCharging: true,
+      descriptiveCapacityRemaining: 'MEDIUM',
+      capacityRemaining: [
+        {
+          rawValue: 50,
+          unit: 'PERCENTAGE'
+        }
+      ]
+    });
+    expect(Command.getResponseStates({ charge: false }, item)).toStrictEqual({
+      isCharging: false,
+      descriptiveCapacityRemaining: 'MEDIUM',
+      capacityRemaining: [
+        {
+          rawValue: 50,
+          unit: 'PERCENTAGE'
+        }
+      ]
+    });
+  });
+});

--- a/tests/devices/charger.test.js
+++ b/tests/devices/charger.test.js
@@ -1,0 +1,354 @@
+const Device = require('../../functions/devices/charger.js');
+
+describe('Charger Device', () => {
+  test('isCompatible', () => {
+    expect(
+      Device.isCompatible({
+        metadata: {
+          ga: {
+            value: 'Charger'
+          }
+        }
+      })
+    ).toBe(true);
+  });
+
+  test('matchesItemType', () => {
+    const item = {
+      type: 'Group',
+      members: [
+        {
+          metadata: {
+            ga: {
+              value: 'chargerCharging'
+            }
+          }
+        }
+      ]
+    };
+    expect(Device.matchesItemType(item)).toBe(true);
+    expect(Device.matchesItemType({ type: 'Group' })).toBe(false);
+  });
+
+  describe('getAttributes', () => {
+    test('getAttributes no config', () => {
+      const item = {
+        metadata: {
+          ga: {
+            config: {}
+          }
+        },
+        members: [
+          {
+            metadata: {
+              ga: {
+                value: 'chargerCapacityRemaining'
+              }
+            }
+          }
+        ]
+      };
+      expect(Device.getAttributes(item)).toStrictEqual({
+        isRechargeable: false,
+        queryOnlyEnergyStorage: true
+      });
+    });
+
+    test('getAttributes with charging', () => {
+      const item = {
+        metadata: {
+          ga: {
+            config: {}
+          }
+        },
+        members: [
+          {
+            metadata: {
+              ga: {
+                value: 'chargerCharging'
+              }
+            }
+          }
+        ]
+      };
+      expect(Device.getAttributes(item)).toStrictEqual({
+        isRechargeable: false,
+        queryOnlyEnergyStorage: false
+      });
+    });
+
+    test('getAttributes with charging', () => {
+      const item = {
+        metadata: {
+          ga: {
+            config: {
+              isRechargeable: true
+            }
+          }
+        },
+        members: [
+          {
+            metadata: {
+              ga: {
+                value: 'chargerCharging'
+              }
+            }
+          }
+        ]
+      };
+      expect(Device.getAttributes(item)).toStrictEqual({
+        isRechargeable: true,
+        queryOnlyEnergyStorage: false
+      });
+    });
+  });
+
+  test('getMembers', () => {
+    expect(Device.getMembers({ members: [{}] })).toStrictEqual({});
+    expect(Device.getMembers({ members: [{ metadata: { ga: { value: 'invalid' } } }] })).toStrictEqual({});
+    const item = {
+      members: [
+        {
+          name: 'Charging',
+          state: 'ON',
+          metadata: {
+            ga: {
+              value: 'chargerCharging'
+            }
+          }
+        },
+        {
+          name: 'CapacityRemaining',
+          state: '40',
+          metadata: {
+            ga: {
+              value: 'chargerCapacityRemaining'
+            }
+          }
+        },
+        {
+          name: 'CapacityUntilFull',
+          state: '60',
+          metadata: {
+            ga: {
+              value: 'chargerCapacityUntilFull'
+            }
+          }
+        }
+      ]
+    };
+    expect(Device.getMembers(item)).toStrictEqual({
+      chargerCharging: {
+        name: 'Charging',
+        state: 'ON'
+      },
+      chargerCapacityRemaining: {
+        name: 'CapacityRemaining',
+        state: '40'
+      },
+      chargerCapacityUntilFull: {
+        name: 'CapacityUntilFull',
+        state: '60'
+      }
+    });
+  });
+
+  describe('getState', () => {
+    test('getState default unit', () => {
+      const item = {
+        type: 'Group',
+        metadata: {
+          ga: {
+            value: 'Charger',
+            config: {}
+          }
+        },
+        members: [
+          {
+            name: 'Charging',
+            state: 'ON',
+            metadata: {
+              ga: {
+                value: 'chargerCharging'
+              }
+            }
+          },
+          {
+            name: 'CapacityRemaining',
+            state: '60',
+            metadata: {
+              ga: {
+                value: 'chargerCapacityRemaining'
+              }
+            }
+          },
+          {
+            name: 'CapacityUntilFull',
+            state: '40',
+            metadata: {
+              ga: {
+                value: 'chargerCapacityUntilFull'
+              }
+            }
+          }
+        ]
+      };
+      expect(Device.getState(item)).toStrictEqual({
+        capacityRemaining: [
+          {
+            rawValue: 60,
+            unit: 'PERCENTAGE'
+          }
+        ],
+        capacityUntilFull: [
+          {
+            rawValue: 40,
+            unit: 'PERCENTAGE'
+          }
+        ],
+        descriptiveCapacityRemaining: 'MEDIUM',
+        isCharging: true
+      });
+
+      item.members[1].state = '10';
+      expect(Device.getState(item)).toStrictEqual({
+        capacityRemaining: [
+          {
+            rawValue: 10,
+            unit: 'PERCENTAGE'
+          }
+        ],
+        capacityUntilFull: [
+          {
+            rawValue: 40,
+            unit: 'PERCENTAGE'
+          }
+        ],
+        descriptiveCapacityRemaining: 'CRITICALLY_LOW',
+        isCharging: true
+      });
+
+      item.members[1].state = '22';
+      expect(Device.getState(item)).toStrictEqual({
+        capacityRemaining: [
+          {
+            rawValue: 22,
+            unit: 'PERCENTAGE'
+          }
+        ],
+        capacityUntilFull: [
+          {
+            rawValue: 40,
+            unit: 'PERCENTAGE'
+          }
+        ],
+        descriptiveCapacityRemaining: 'LOW',
+        isCharging: true
+      });
+
+      item.members[1].state = '80';
+      expect(Device.getState(item)).toStrictEqual({
+        capacityRemaining: [
+          {
+            rawValue: 80,
+            unit: 'PERCENTAGE'
+          }
+        ],
+        capacityUntilFull: [
+          {
+            rawValue: 40,
+            unit: 'PERCENTAGE'
+          }
+        ],
+        descriptiveCapacityRemaining: 'HIGH',
+        isCharging: true
+      });
+
+      item.members[1].state = '100';
+      expect(Device.getState(item)).toStrictEqual({
+        capacityRemaining: [
+          {
+            rawValue: 100,
+            unit: 'PERCENTAGE'
+          }
+        ],
+        capacityUntilFull: [
+          {
+            rawValue: 40,
+            unit: 'PERCENTAGE'
+          }
+        ],
+        descriptiveCapacityRemaining: 'FULL',
+        isCharging: true
+      });
+    });
+
+    test('getState KILOWATT_HOURS unit', () => {
+      const item = {
+        type: 'Group',
+        metadata: {
+          ga: {
+            value: 'Charger',
+            config: {
+              unit: 'KILOWATT_HOURS'
+            }
+          }
+        },
+        members: [
+          {
+            name: 'Charging',
+            state: 'OFF',
+            metadata: {
+              ga: {
+                value: 'chargerCharging'
+              }
+            }
+          },
+          {
+            name: 'PluggedIn',
+            state: 'ON',
+            metadata: {
+              ga: {
+                value: 'chargerPluggedIn'
+              }
+            }
+          },
+          {
+            name: 'CapacityRemaining',
+            state: '4000',
+            metadata: {
+              ga: {
+                value: 'chargerCapacityRemaining'
+              }
+            }
+          },
+          {
+            name: 'CapacityUntilFull',
+            state: '6000',
+            metadata: {
+              ga: {
+                value: 'chargerCapacityUntilFull'
+              }
+            }
+          }
+        ]
+      };
+      expect(Device.getState(item)).toStrictEqual({
+        capacityRemaining: [
+          {
+            rawValue: 4000,
+            unit: 'KILOWATT_HOURS'
+          }
+        ],
+        capacityUntilFull: [
+          {
+            rawValue: 6000,
+            unit: 'KILOWATT_HOURS'
+          }
+        ],
+        isCharging: false,
+        isPluggedIn: true
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds the `Charger` device type together with the `EnergyStorage` trait.

| | |
|---|---|
| **Device Type** | [Charger](https://developers.google.com/assistant/smarthome/guides/charger) |
| **Supported Traits** | [EnergyStorage](https://developers.google.com/assistant/smarthome/traits/energystorage) |
| **Supported Items** | Group as `Charger` with the following optional members: Switch as `chargerCharging`, Switch as `chargerPluggedIn`, Number or Dimmer as `chargerCapacityRemaining`, Number or Dimmer as `chargerCapacityUntilFull` |
| **Configuration** | (optional) `isRechargeable=true/false`<br>(optional) `unit="PERCENTAGE"` |

The configuration option `unit` supports the following values: `PERCENTAGE` (default), `SECONDS`, `MILES`, `KILOMETERS`, `KILOWATT_HOURS`

The setting `isRechargeable` defaults to `false` if not explicitly set to `true`.

If no `chargerCharging` item is specified, the device will only support queries.

```shell
Group  chargerGroup { ga="Charger" [ isRechargeable=true, unit="KILOWATT_HOURS" ] }
Switch chargingItem         (chargerGroup) { ga="chargerCharging" }
Switch pluggedInItem        (chargerGroup) { ga="chargerPluggedIn" }
Number capacityRemainItem   (chargerGroup) { ga="chargerCapacityRemaining" }
Number capacityFullItem     (chargerGroup) { ga="chargerCapacityUntilFull" }
```

Will resolve #300 