### PR TITLE
Add MediaState trait to TV

### DIFF
--- a/functions/devices/tv.js
+++ b/functions/devices/tv.js
@@ -12,7 +12,8 @@ class TV extends DefaultDevice {
     if ('tvMute' in members || 'tvVolume' in members) traits.push('action.devices.traits.Volume');
     if ('tvChannel' in members) traits.push('action.devices.traits.Channel');
     if ('tvInput' in members) traits.push('action.devices.traits.InputSelector');
-    if ('tvTransport' in members) traits.push('action.devices.traits.TransportControl');
+    if ('tvTransport' in members)
+      traits.push('action.devices.traits.TransportControl', 'action.devices.traits.MediaState');
     if ('tvApplication' in members) traits.push('action.devices.traits.AppSelector');
     return traits;
   }
@@ -40,6 +41,7 @@ class TV extends DefaultDevice {
       }
     }
     if ('tvTransport' in members) {
+      attributes.supportPlaybackState = true;
       attributes.transportControlSupportedCommands = ['NEXT', 'PREVIOUS', 'PAUSE', 'RESUME'];
       if ('transportControlSupportedCommands' in config) {
         attributes.transportControlSupportedCommands = config.transportControlSupportedCommands
@@ -105,6 +107,9 @@ class TV extends DefaultDevice {
           break;
         case 'tvInput':
           state.currentInput = members[member].state;
+          break;
+        case 'tvTransport':
+          state.playbackState = members[member].state;
           break;
         case 'tvVolume':
           state.currentVolume = Number(members[member].state) || 0;

--- a/tests/devices/tv.test.js
+++ b/tests/devices/tv.test.js
@@ -75,7 +75,7 @@ describe('TV Device', () => {
             }
           },
           {
-            state: 'PLAY',
+            state: 'PLAYING',
             metadata: {
               ga: {
                 value: 'tvTransport'
@@ -114,6 +114,7 @@ describe('TV Device', () => {
         'action.devices.traits.Channel',
         'action.devices.traits.InputSelector',
         'action.devices.traits.TransportControl',
+        'action.devices.traits.MediaState',
         'action.devices.traits.AppSelector'
       ]);
     });
@@ -145,6 +146,7 @@ describe('TV Device', () => {
         ]
       };
       expect(Device.getAttributes(item)).toStrictEqual({
+        supportPlaybackState: true,
         transportControlSupportedCommands: ['NEXT', 'PREVIOUS', 'PAUSE', 'RESUME'],
         volumeCanMuteAndUnmute: false,
         volumeMaxLevel: 100
@@ -207,6 +209,7 @@ describe('TV Device', () => {
         ]
       };
       expect(Device.getAttributes(item)).toStrictEqual({
+        supportPlaybackState: true,
         transportControlSupportedCommands: ['PAUSE', 'RESUME'],
         volumeCanMuteAndUnmute: true
       });
@@ -513,7 +516,7 @@ describe('TV Device', () => {
             }
           },
           {
-            state: 'PLAY',
+            state: 'PLAYING',
             metadata: {
               ga: {
                 value: 'tvTransport'
@@ -547,6 +550,7 @@ describe('TV Device', () => {
         ]
       };
       expect(Device.getState(item)).toStrictEqual({
+        playbackState: 'PLAYING',
         channelName: 'ARD',
         channelNumber: '1',
         currentInput: 'input1',


### PR DESCRIPTION
This PR adds the MediaState trait to the TV device type.
Does not change anything for the configuration itself. It will use the `tvTransport` member for the state.

Ref.: https://developers.google.com/assistant/smarthome/traits/mediastate

Resolves #240 