### PR TITLE
Bring back UP & DOWN for open close devices

### DIFF
--- a/functions/commands/charge.js
+++ b/functions/commands/charge.js
@@ -24,7 +24,7 @@ class Charge extends DefaultCommand {
 
   static convertParamsToValue(params, _, device) {
     let charge = params.charge;
-    if (this.isInverted(device) === true) {
+    if (this.isInverted(device)) {
       charge = !charge;
     }
     return charge ? 'ON' : 'OFF';

--- a/functions/commands/mute.js
+++ b/functions/commands/mute.js
@@ -42,7 +42,7 @@ class Mute extends DefaultCommand {
     if (itemType !== 'Switch') {
       return mute ? '0' : undefined;
     }
-    if (this.isInverted(device) === true) {
+    if (this.isInverted(device)) {
       mute = !mute;
     }
     return mute ? 'ON' : 'OFF';

--- a/functions/commands/onoff.js
+++ b/functions/commands/onoff.js
@@ -39,7 +39,7 @@ class OnOff extends DefaultCommand {
 
   static convertParamsToValue(params, _, device) {
     let on = params.on;
-    if (this.isInverted(device) === true) {
+    if (this.isInverted(device)) {
       on = !on;
     }
     return on ? 'ON' : 'OFF';

--- a/functions/commands/openclose.js
+++ b/functions/commands/openclose.js
@@ -15,7 +15,7 @@ class OpenClose extends DefaultCommand {
       throw { statusCode: 400 };
     }
     let openPercent = params.openPercent;
-    if (this.isInverted(device) === true) {
+    if (this.isInverted(device)) {
       openPercent = 100 - openPercent;
     }
     if (itemType === 'Rollershutter') {

--- a/functions/commands/openclose.js
+++ b/functions/commands/openclose.js
@@ -19,7 +19,7 @@ class OpenClose extends DefaultCommand {
       openPercent = 100 - openPercent;
     }
     if (itemType === 'Rollershutter') {
-      return (100 - openPercent).toString();
+      return openPercent === 0 ? 'DOWN' : openPercent === 100 ? 'UP' : (100 - openPercent).toString();
     }
     if (itemType === 'Switch') {
       return openPercent === 0 ? 'OFF' : 'ON';
@@ -34,7 +34,8 @@ class OpenClose extends DefaultCommand {
   }
 
   static checkCurrentState(target, state, params) {
-    if (target === state) {
+    const adjustedTarget = target === 'DOWN' ? '100' : target === 'UP' ? '0' : target;
+    if (adjustedTarget === state) {
       throw { errorCode: params.openPercent === 0 ? 'alreadyClosed' : 'alreadyOpen' };
     }
   }

--- a/tests/commands/default.test.js
+++ b/tests/commands/default.test.js
@@ -71,6 +71,13 @@ describe('Default Command', () => {
     expect(Command.getItemName({ name: 'Item' }, {})).toBe('Item');
   });
 
+  test('isInverted', () => {
+    expect(Command.isInverted({})).toBe(false);
+    expect(Command.isInverted({ id: 'Item', customData: {} })).toBe(false);
+    expect(Command.isInverted({ id: 'Item', customData: { inverted: false } })).toBe(false);
+    expect(Command.isInverted({ id: 'Item', customData: { inverted: true } })).toBe(true);
+  });
+
   test('requiresItem', () => {
     expect(Command.requiresItem({})).toBe(false);
   });

--- a/tests/commands/openclose.test.js
+++ b/tests/commands/openclose.test.js
@@ -27,9 +27,9 @@ describe('OpenClose Command', () => {
 
     test('convertParamsToValue Rollershutter', () => {
       const device = { customData: { itemType: 'Rollershutter' } };
-      expect(Command.convertParamsToValue({ openPercent: 0 }, {}, device)).toBe('100');
+      expect(Command.convertParamsToValue({ openPercent: 0 }, {}, device)).toBe('DOWN');
       expect(Command.convertParamsToValue({ openPercent: 20 }, {}, device)).toBe('80');
-      expect(Command.convertParamsToValue({ openPercent: 100 }, {}, device)).toBe('0');
+      expect(Command.convertParamsToValue({ openPercent: 100 }, {}, device)).toBe('UP');
     });
 
     test('convertParamsToValue Switch', () => {
@@ -53,7 +53,7 @@ describe('OpenClose Command', () => {
 
   describe('checkCurrentState', () => {
     test('Switch', () => {
-      expect.assertions(4);
+      expect.assertions(8);
 
       expect(Command.checkCurrentState('ON', 'OFF', { openPercent: 100 })).toBeUndefined();
       try {
@@ -65,6 +65,20 @@ describe('OpenClose Command', () => {
       expect(Command.checkCurrentState('OFF', 'ON', { openPercent: 0 })).toBeUndefined();
       try {
         Command.checkCurrentState('OFF', 'OFF', { openPercent: 0 });
+      } catch (e) {
+        expect(e.errorCode).toBe('alreadyClosed');
+      }
+
+      expect(Command.checkCurrentState('UP', '100', { openPercent: 100 })).toBeUndefined();
+      try {
+        Command.checkCurrentState('UP', '0', { openPercent: 100 });
+      } catch (e) {
+        expect(e.errorCode).toBe('alreadyOpen');
+      }
+
+      expect(Command.checkCurrentState('DOWN', '0', { openPercent: 0 })).toBeUndefined();
+      try {
+        Command.checkCurrentState('DOWN', '100', { openPercent: 0 });
       } catch (e) {
         expect(e.errorCode).toBe('alreadyClosed');
       }


### PR DESCRIPTION
In #319 we changed the way how the openClose command sends values to openHAB items to be able to compare the desired and actual states.

This lead to unexpected behaviors on the user's side as reported in https://community.openhab.org/t/openhab-google-assistant-a-new-version-is-released/126996/10

This PR again adds UP/DOWN as commands sent and adjust the state comparison accordingly.