### PR TITLE
Add support for color temperature in Mired & Use separate identifier for SpecialColorLight

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -73,10 +73,10 @@ Color  { ga="Light" [ colorTemperatureRange="2000,9000" ] }
 | **Device Type** | [Light](https://developers.google.com/assistant/smarthome/guides/light) |
 | **Supported Traits** | [OnOff](https://developers.google.com/assistant/smarthome/traits/onoff), [ColorSetting](https://developers.google.com/assistant/smarthome/traits/colorsetting), [Brightness](https://developers.google.com/assistant/smarthome/traits/brightness) |
 | **Supported Items** | Group as `light` with the following members: (optional) Number or Dimmer as `lightBrightness`, (optional) Number or Dimmer as `lightColorTemperature`, (optional) Color as `lightColor`, (optional) Switch as `lightPower` |
-| **Configuration** | (optional) `useKelvin=true/false`<br>(optional) `checkState=true/false`<br>(optional) `colorTemperatureRange="minK,maxK"`<br>_Hint: if you want to use `lightColorTemperature` you either need to set `useKelvin=true` or `colorTemperatureRange`_ |
+| **Configuration** | (optional) `colorUnit=percent/kelvin/mired`<br>(optional) `checkState=true/false`<br>(optional) `colorTemperatureRange="minK,maxK"`<br>_Hint: if you want to use `lightColorTemperature` you either need to set `colorUnit` to `kelvin` or `mired` or define a `colorTemperatureRange` as `colorUnit` defaults to `percent`_ |
 
 ```shell
-Group  lightGroup { ga="Light" [ useKelvin=true, colorTemperatureRange="2000,9000" ] }
+Group  lightGroup { ga="Light" [ colorUnit="kelvin", colorTemperatureRange="2000,9000" ] }
 Switch powerItem            (lightGroup) { ga="lightPower" }
 Dimmer brightnessItem       (lightGroup) { ga="lightBrightness" }
 Color  colorItem            (lightGroup) { ga="lightColor" }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -66,17 +66,17 @@ Dimmer { ga="Light" }
 Color  { ga="Light" [ colorTemperatureRange="2000,9000" ] }
 ```
 
-#### `Light as Group with separate Color and Brightness`
+#### `Light as Group with separate Controls`
 
 | | |
 |---|---|
 | **Device Type** | [Light](https://developers.google.com/assistant/smarthome/guides/light) |
 | **Supported Traits** | [OnOff](https://developers.google.com/assistant/smarthome/traits/onoff), [ColorSetting](https://developers.google.com/assistant/smarthome/traits/colorsetting), [Brightness](https://developers.google.com/assistant/smarthome/traits/brightness) |
-| **Supported Items** | Group as `light` with the following members: (optional) Number or Dimmer as `lightBrightness`, (optional) Number or Dimmer as `lightColorTemperature`, (optional) Color as `lightColor`, (optional) Switch as `lightPower` |
+| **Supported Items** | Group as `SpecialColorLight` with the following members: (optional) Number or Dimmer as `lightBrightness`, (optional) Number or Dimmer as `lightColorTemperature`, (optional) Color as `lightColor`, (optional) Switch as `lightPower` |
 | **Configuration** | (optional) `colorUnit=percent/kelvin/mired`<br>(optional) `checkState=true/false`<br>(optional) `colorTemperatureRange="minK,maxK"`<br>_Hint: if you want to use `lightColorTemperature` you either need to set `colorUnit` to `kelvin` or `mired` or define a `colorTemperatureRange` as `colorUnit` defaults to `percent`_ |
 
 ```shell
-Group  lightGroup { ga="Light" [ colorUnit="kelvin", colorTemperatureRange="2000,9000" ] }
+Group  lightGroup { ga="SpecialColorLight" [ colorUnit="kelvin", colorTemperatureRange="2000,9000" ] }
 Switch powerItem            (lightGroup) { ga="lightPower" }
 Dimmer brightnessItem       (lightGroup) { ga="lightBrightness" }
 Color  colorItem            (lightGroup) { ga="lightColor" }

--- a/functions/commands/colorabsolutetemperature.js
+++ b/functions/commands/colorabsolutetemperature.js
@@ -1,7 +1,6 @@
 const DefaultCommand = require('./default.js');
 const SpecialColorLight = require('../devices/specialcolorlight.js');
-const rgb2hsv = require('../utilities.js').rgb2hsv;
-const kelvin2rgb = require('../utilities.js').kelvin2rgb;
+const { convertMired, convertRgbToHsv, convertKelvinToRgb } = require('../utilities.js');
 
 class ColorAbsoluteTemperature extends DefaultCommand {
   static get type() {
@@ -35,8 +34,12 @@ class ColorAbsoluteTemperature extends DefaultCommand {
   static convertParamsToValue(params, item, device) {
     if (this.getDeviceType(device) === 'SpecialColorLight') {
       try {
-        if (SpecialColorLight.useKelvin(item)) {
+        const colorUnit = SpecialColorLight.getColorUnit(item);
+        if (colorUnit === 'kelvin') {
           return params.color.temperature.toString();
+        }
+        if (colorUnit === 'mired') {
+          return convertMired(params.color.temperature).toString();
         }
         const { temperatureMinK, temperatureMaxK } = SpecialColorLight.getAttributes(item).colorTemperatureRange;
         return (
@@ -47,7 +50,7 @@ class ColorAbsoluteTemperature extends DefaultCommand {
         return '0';
       }
     }
-    const hsv = rgb2hsv(kelvin2rgb(params.color.temperature));
+    const hsv = convertRgbToHsv(convertKelvinToRgb(params.color.temperature));
     const hsvArray = item.state.split(',').map((val) => Number(val));
     return [Math.round(hsv.hue * 100) / 100, Math.round(hsv.saturation * 1000) / 10, hsvArray[2]].join(',');
   }

--- a/functions/commands/thermostattemperaturesetpoint.js
+++ b/functions/commands/thermostattemperaturesetpoint.js
@@ -1,6 +1,6 @@
 const DefaultCommand = require('./default.js');
 const Thermostat = require('../devices/thermostat.js');
-const convertToFahrenheit = require('../utilities.js').convertToFahrenheit;
+const convertCelsiusToFahrenheit = require('../utilities.js').convertCelsiusToFahrenheit;
 
 class ThermostatTemperatureSetpoint extends DefaultCommand {
   static get type() {
@@ -26,7 +26,7 @@ class ThermostatTemperatureSetpoint extends DefaultCommand {
   static convertParamsToValue(params, item) {
     let value = params.thermostatTemperatureSetpoint;
     if (Thermostat.useFahrenheit(item)) {
-      value = convertToFahrenheit(value);
+      value = convertCelsiusToFahrenheit(value);
     }
     return value.toString();
   }

--- a/functions/commands/thermostattemperaturesetpointhigh.js
+++ b/functions/commands/thermostattemperaturesetpointhigh.js
@@ -1,6 +1,6 @@
 const DefaultCommand = require('./default.js');
 const Thermostat = require('../devices/thermostat.js');
-const convertToFahrenheit = require('../utilities.js').convertToFahrenheit;
+const convertCelsiusToFahrenheit = require('../utilities.js').convertCelsiusToFahrenheit;
 
 class ThermostatTemperatureSetpointHigh extends DefaultCommand {
   static get type() {
@@ -28,7 +28,7 @@ class ThermostatTemperatureSetpointHigh extends DefaultCommand {
   static convertParamsToValue(params, item) {
     let value = params.thermostatTemperatureSetpointHigh;
     if (Thermostat.useFahrenheit(item)) {
-      value = convertToFahrenheit(value);
+      value = convertCelsiusToFahrenheit(value);
     }
     return value.toString();
   }

--- a/functions/commands/thermostattemperaturesetpointlow.js
+++ b/functions/commands/thermostattemperaturesetpointlow.js
@@ -1,6 +1,6 @@
 const DefaultCommand = require('./default.js');
 const Thermostat = require('../devices/thermostat.js');
-const convertToFahrenheit = require('../utilities.js').convertToFahrenheit;
+const convertCelsiusToFahrenheit = require('../utilities.js').convertCelsiusToFahrenheit;
 
 class ThermostatTemperatureSetpointLow extends DefaultCommand {
   static get type() {
@@ -26,7 +26,7 @@ class ThermostatTemperatureSetpointLow extends DefaultCommand {
   static convertParamsToValue(params, item) {
     let value = params.thermostatTemperatureSetpointLow;
     if (Thermostat.useFahrenheit(item)) {
-      value = convertToFahrenheit(value);
+      value = convertCelsiusToFahrenheit(value);
     }
     return value.toString();
   }

--- a/functions/devices/specialcolorlight.js
+++ b/functions/devices/specialcolorlight.js
@@ -10,6 +10,10 @@ class SpecialColorLight extends DefaultDevice {
     return ['action.devices.traits.OnOff', 'action.devices.traits.Brightness', 'action.devices.traits.ColorSetting'];
   }
 
+  static isCompatible(item = {}) {
+    return item.metadata && item.metadata.ga && item.metadata.ga.value.toLowerCase() == 'specialcolorlight';
+  }
+
   static matchesItemType(item) {
     const members = this.getMembers(item);
     return (

--- a/functions/devices/specialcolorlight.js
+++ b/functions/devices/specialcolorlight.js
@@ -35,9 +35,10 @@ class SpecialColorLight extends DefaultDevice {
     if ('colorTemperatureRange' in config) {
       const [min, max] = config.colorTemperatureRange.split(',').map((s) => Number(s.trim()));
       if (!isNaN(min) && !isNaN(max)) {
+        const colorUnit = this.getColorUnit(item);
         attributes.colorTemperatureRange = {
-          temperatureMinK: min,
-          temperatureMaxK: max
+          temperatureMinK: colorUnit === 'mired' ? convertMired(max) : min,
+          temperatureMaxK: colorUnit === 'mired' ? convertMired(min) : max
         };
       }
     }

--- a/functions/devices/temperaturesensor.js
+++ b/functions/devices/temperaturesensor.js
@@ -1,5 +1,5 @@
 const DefaultDevice = require('./default.js');
-const convertToCelsius = require('../utilities.js').convertToCelsius;
+const convertFahrenheitToCelsius = require('../utilities.js').convertFahrenheitToCelsius;
 
 class TemperatureSensor extends DefaultDevice {
   static get type() {
@@ -28,7 +28,7 @@ class TemperatureSensor extends DefaultDevice {
   static getState(item) {
     let state = Number(parseFloat(item.state).toFixed(1));
     if (this.getConfig(item).useFahrenheit === true) {
-      state = convertToCelsius(state);
+      state = convertFahrenheitToCelsius(state);
     }
     return {
       temperatureSetpointCelsius: state,

--- a/functions/devices/thermostat.js
+++ b/functions/devices/thermostat.js
@@ -1,5 +1,5 @@
 const DefaultDevice = require('./default.js');
-const convertToCelsius = require('../utilities.js').convertToCelsius;
+const convertFahrenheitToCelsius = require('../utilities.js').convertFahrenheitToCelsius;
 
 class Thermostat extends DefaultDevice {
   static get type() {
@@ -50,7 +50,7 @@ class Thermostat extends DefaultDevice {
       } else {
         state[member] = Number(parseFloat(members[member].state).toFixed(1));
         if (member.indexOf('Temperature') > 0 && this.useFahrenheit(item)) {
-          state[member] = convertToCelsius(state[member]);
+          state[member] = convertFahrenheitToCelsius(state[member]);
         }
       }
     }

--- a/functions/utilities.js
+++ b/functions/utilities.js
@@ -23,22 +23,22 @@ module.exports = {
    * @param {number} value temperature in Fahrenheit
    * @returns {number} temperature value converted to Celsius
    */
-  convertToCelsius: (value) => {
+  convertFahrenheitToCelsius: (value) => {
     return Number((((value - 32) * 5) / 9).toFixed(1));
   },
   /**
    * @param {number} value temperature in Celsius
    * @returns {number} temperature value converted to Fahrenheit
    */
-  convertToFahrenheit: (value) => {
+  convertCelsiusToFahrenheit: (value) => {
     return Math.round((value * 9) / 5 + 32);
   },
   /**
-   * @param {number} kelvin color temperature as Kelvin
+   * @param {number} value color temperature as Kelvin
    * @returns {object} color temperature value converted to RGB
    */
-  kelvin2rgb: (kelvin) => {
-    const temp = kelvin / 100;
+  convertKelvinToRgb: (value) => {
+    const temp = value / 100;
     const r = temp <= 66 ? 255 : 329.698727446 * Math.pow(temp - 60, -0.1332047592);
     const g =
       temp <= 66
@@ -52,10 +52,17 @@ module.exports = {
     };
   },
   /**
+   * @param {number} value color temperature as Kelvin or Mired
+   * @returns {number} color temperature value converted to Mired or Kelvin
+   */
+  convertMired: (value) => {
+    return Math.round(Math.pow(10, 6) / value);
+  },
+  /**
    * @param {object} rgb color as RGB
    * @returns {object} color value converted to HSV
    */
-  rgb2hsv: ({ r, g, b }) => {
+  convertRgbToHsv: ({ r, g, b }) => {
     r = r / 255;
     g = g / 255;
     b = b / 255;

--- a/tests/commands/colorabsolutetemperature.test.js
+++ b/tests/commands/colorabsolutetemperature.test.js
@@ -63,13 +63,27 @@ describe('ColorAbsoluteTemperature Command', () => {
         metadata: {
           ga: {
             config: {
-              useKelvin: true
+              colorUnit: 'kelvin'
             }
           }
         }
       };
       const device = { customData: { deviceType: 'SpecialColorLight' } };
       expect(Command.convertParamsToValue(params, item, device)).toBe('2000');
+    });
+
+    test('convertParamsToValue SpecialColorLight Mired', () => {
+      const item = {
+        metadata: {
+          ga: {
+            config: {
+              colorUnit: 'mired'
+            }
+          }
+        }
+      };
+      const device = { customData: { deviceType: 'SpecialColorLight' } };
+      expect(Command.convertParamsToValue(params, item, device)).toBe('500');
     });
   });
 

--- a/tests/devices/specialcolorlight.test.js
+++ b/tests/devices/specialcolorlight.test.js
@@ -14,7 +14,7 @@ describe('SpecialColorLight Device', () => {
   });
 
   test('matchesItemType', () => {
-    const item = {
+    const item1 = {
       type: 'Group',
       metadata: {
         ga: {
@@ -71,7 +71,7 @@ describe('SpecialColorLight Device', () => {
         ga: {
           value: 'LIGHT',
           config: {
-            useKelvin: true
+            colorUnit: 'kelvin'
           }
         }
       },
@@ -164,12 +164,40 @@ describe('SpecialColorLight Device', () => {
         }
       ]
     };
-    expect(Device.matchesItemType(item)).toBe(true);
+    const item7 = {
+      type: 'Group',
+      metadata: {
+        ga: {
+          value: 'LIGHT',
+          config: {
+            colorUnit: 'mired'
+          }
+        }
+      },
+      members: [
+        {
+          metadata: {
+            ga: {
+              value: 'lightBrightness'
+            }
+          }
+        },
+        {
+          metadata: {
+            ga: {
+              value: 'lightColorTemperature'
+            }
+          }
+        }
+      ]
+    };
+    expect(Device.matchesItemType(item1)).toBe(true);
     expect(Device.matchesItemType(item2)).toBe(false);
     expect(Device.matchesItemType(item3)).toBe(true);
     expect(Device.matchesItemType(item4)).toBe(true);
     expect(Device.matchesItemType(item5)).toBe(true);
     expect(Device.matchesItemType(item6)).toBe(false);
+    expect(Device.matchesItemType(item7)).toBe(true);
     expect(Device.matchesItemType({ type: 'Color' })).toBe(false);
     expect(Device.matchesItemType({ type: 'Group', groupType: 'Color' })).toBe(false);
     expect(Device.matchesItemType({ type: 'Group', groupType: 'Dimmer' })).toBe(false);
@@ -283,7 +311,7 @@ describe('SpecialColorLight Device', () => {
           ga: {
             value: 'LIGHT',
             config: {
-              useKelvin: true
+              colorUnit: 'kelvin'
             }
           }
         },
@@ -311,6 +339,45 @@ describe('SpecialColorLight Device', () => {
         brightness: 50,
         color: {
           temperatureK: 2000
+        }
+      });
+    });
+
+    test('getState mired', () => {
+      const item = {
+        type: 'Group',
+        metadata: {
+          ga: {
+            value: 'LIGHT',
+            config: {
+              colorUnit: 'mired'
+            }
+          }
+        },
+        members: [
+          {
+            state: '50',
+            metadata: {
+              ga: {
+                value: 'lightBrightness'
+              }
+            }
+          },
+          {
+            state: '200',
+            metadata: {
+              ga: {
+                value: 'lightColorTemperature'
+              }
+            }
+          }
+        ]
+      };
+      expect(Device.getState(item)).toStrictEqual({
+        on: true,
+        brightness: 50,
+        color: {
+          temperatureK: 5000
         }
       });
     });
@@ -350,46 +417,6 @@ describe('SpecialColorLight Device', () => {
         brightness: 0,
         color: {
           temperatureK: 3400
-        }
-      });
-    });
-
-    test('getState use kelvin', () => {
-      const item = {
-        type: 'Group',
-        metadata: {
-          ga: {
-            value: 'LIGHT',
-            config: {
-              colorTemperatureRange: '1000,4000',
-              useKelvin: true
-            }
-          }
-        },
-        members: [
-          {
-            state: '50',
-            metadata: {
-              ga: {
-                value: 'lightBrightness'
-              }
-            }
-          },
-          {
-            state: '2000',
-            metadata: {
-              ga: {
-                value: 'lightColorTemperature'
-              }
-            }
-          }
-        ]
-      };
-      expect(Device.getState(item)).toStrictEqual({
-        on: true,
-        brightness: 50,
-        color: {
-          temperatureK: 2000
         }
       });
     });

--- a/tests/devices/specialcolorlight.test.js
+++ b/tests/devices/specialcolorlight.test.js
@@ -235,6 +235,25 @@ describe('SpecialColorLight Device', () => {
       expect(Device.getAttributes(item1)).toStrictEqual({});
     });
 
+    test('getAttributes colorTemperatureRange with mired', () => {
+      const item = {
+        metadata: {
+          ga: {
+            config: {
+              colorUnit: 'mired',
+              colorTemperatureRange: '250,454'
+            }
+          }
+        }
+      };
+      expect(Device.getAttributes(item)).toStrictEqual({
+        colorTemperatureRange: {
+          temperatureMinK: 2203,
+          temperatureMaxK: 4000
+        }
+      });
+    });
+
     test('getAttributes color', () => {
       const item = {
         metadata: {

--- a/tests/devices/specialcolorlight.test.js
+++ b/tests/devices/specialcolorlight.test.js
@@ -6,7 +6,7 @@ describe('SpecialColorLight Device', () => {
       Device.isCompatible({
         metadata: {
           ga: {
-            value: 'LIGHT'
+            value: 'SpecialColorLight'
           }
         }
       })

--- a/tests/utilities.test.js
+++ b/tests/utilities.test.js
@@ -1,27 +1,36 @@
 const Utilities = require('../functions/utilities.js');
 
 describe('Utilities', () => {
-  test('convertToCelsius', () => {
-    expect(Utilities.convertToCelsius(10.0)).toEqual(-12.2);
-    expect(Utilities.convertToCelsius(0.0)).toEqual(-17.8);
+  test('convertFahrenheitToCelsius', () => {
+    expect(Utilities.convertFahrenheitToCelsius(10.0)).toEqual(-12.2);
+    expect(Utilities.convertFahrenheitToCelsius(0.0)).toEqual(-17.8);
   });
 
-  test('convertToFahrenheit', () => {
-    expect(Utilities.convertToFahrenheit(10.0)).toEqual(50);
-    expect(Utilities.convertToFahrenheit(0.0)).toEqual(32);
+  test('convertCelsiusToFahrenheit', () => {
+    expect(Utilities.convertCelsiusToFahrenheit(10.0)).toEqual(50);
+    expect(Utilities.convertCelsiusToFahrenheit(0.0)).toEqual(32);
   });
 
-  test('kelvin2rgb', () => {
-    expect(Utilities.kelvin2rgb(2000)).toStrictEqual({ b: 14, g: 137, r: 255 });
-    expect(Utilities.kelvin2rgb(5900)).toEqual({ b: 234, g: 244, r: 255 });
-    expect(Utilities.kelvin2rgb(9000)).toEqual({ b: 255, g: 223, r: 210 });
+  test('convertKelvinToRgb', () => {
+    expect(Utilities.convertKelvinToRgb(2000)).toStrictEqual({ b: 14, g: 137, r: 255 });
+    expect(Utilities.convertKelvinToRgb(5900)).toEqual({ b: 234, g: 244, r: 255 });
+    expect(Utilities.convertKelvinToRgb(9000)).toEqual({ b: 255, g: 223, r: 210 });
   });
 
-  test('rgb2hsv', () => {
-    expect(Utilities.rgb2hsv({ r: 50, g: 10, b: 100 })).toStrictEqual({ hue: 266.67, saturation: 0.9, value: 0.39 });
-    expect(Utilities.rgb2hsv({ r: 0, g: 0, b: 0 })).toStrictEqual({ hue: 0, saturation: 0, value: 0 });
-    expect(Utilities.rgb2hsv({ r: 255, g: 0, b: 0 })).toStrictEqual({ hue: 0, saturation: 1, value: 1 });
-    expect(Utilities.rgb2hsv({ r: 0, g: 255, b: 0 })).toStrictEqual({ hue: 120, saturation: 1, value: 1 });
-    expect(Utilities.rgb2hsv({ r: 0, g: 0, b: 255 })).toStrictEqual({ hue: 240, saturation: 1, value: 1 });
+  test('convertKelvinToMired', () => {
+    expect(Utilities.convertMired(3400)).toBe(294);
+    expect(Utilities.convertMired(294)).toBe(3401);
+  });
+
+  test('convertRgbToHsv', () => {
+    expect(Utilities.convertRgbToHsv({ r: 50, g: 10, b: 100 })).toStrictEqual({
+      hue: 266.67,
+      saturation: 0.9,
+      value: 0.39
+    });
+    expect(Utilities.convertRgbToHsv({ r: 0, g: 0, b: 0 })).toStrictEqual({ hue: 0, saturation: 0, value: 0 });
+    expect(Utilities.convertRgbToHsv({ r: 255, g: 0, b: 0 })).toStrictEqual({ hue: 0, saturation: 1, value: 1 });
+    expect(Utilities.convertRgbToHsv({ r: 0, g: 255, b: 0 })).toStrictEqual({ hue: 120, saturation: 1, value: 1 });
+    expect(Utilities.convertRgbToHsv({ r: 0, g: 0, b: 255 })).toStrictEqual({ hue: 240, saturation: 1, value: 1 });
   });
 });


### PR DESCRIPTION
This PR adds support for color temperature values in [Mired](https://en.wikipedia.org/wiki/Mired).

For using Mired you will be able to state `colorUnit="mired"` in the `SpecialColorLight` item metadata config.
If `colorUnit` is not defined it defaults to `percent` and will still require you to set a `colorTemperatureRange`.

In addition, the identifier for the SpecialColorLight was changed to `SpecialColorLight` to prevent wrong device assignments for special group configurations.

⚠️ This introduces breaking changes:
- `ga="light"` for SpecialColorLight is replaced by `ga="specialcolorlight"`
- `useKelvin=true` is replaced by `colorUnit="kelvin"`

Should solve #316 and #334