### PR TITLE
Adding AC_UNIT type

### DIFF
--- a/functions/devices/acunit.js
+++ b/functions/devices/acunit.js
@@ -1,0 +1,54 @@
+const DefaultDevice = require('./default.js');
+const fan = require('./fan')
+const thermostat = require('./thermostat')
+
+class Thermostat extends DefaultDevice {
+  static get type() {
+    return 'action.devices.types.AC_UNIT';
+  }
+
+  static getTraits() {
+    return ['action.devices.traits.TemperatureSetting',
+            'action.devices.traits.FanSpeed',
+            'action.devices.traits.OnOff'];
+  }
+  
+
+  static matchesItemType(item) {
+    return item.type === 'Group' && Object.keys(this.getMembers(item)).length > 0;
+  }
+
+  static getAttributes(item) {
+    const attributes = {
+      ...fan.getAttributes(item),
+      ...thermostat.getAttributes(item)
+    };
+
+    return attributes;
+  }
+
+  static getState(item) {
+    const state = {
+        ...fan.getState(item),
+        ...thermostat.getState(item),
+        ...this.getAcPowerState(item)
+    };
+    return state;
+  }
+
+  static getAcPowerState(item) {
+    if (item.members && item.members.length) {
+      item.members.forEach((member) => {
+        if (member.metadata && member.metadata.ga) {
+          if(member.metadata.ga.value.toLowerCase() === 'acpower') {
+              return {on: member.state}
+          }
+        }
+      });
+    }
+    return {};
+  }
+ 
+}
+
+module.exports = Thermostat;


### PR DESCRIPTION
Was trying to figure out how to get my AC to work like they do in my Sensibo and got suggestion that I needed the AC_UNIT type from [this thread.](https://community.openhab.org/t/thermostat-power-option-from-google-assistant/135509/4)

After digging into the [Air Conditioning Unit guide](https://developers.google.com/assistant/smarthome/guides/acunit) I felt pretty confident that this is pretty much a combination of the `Fan` device type and the `Thermostat` device type, plus an added Power Switch (it looks like `Fan` uses fanSpeed for on/off state). I set the base class as `DefaultDevice` because I didn't know how to handle the double inheritance, but I understand this might be a bad way to do it.

I have not tested this PR yet since the steps to get a test Instance running don't seem trivial and wanted to get feedback on my approach first before committing that much effort.