### PR TITLE
Add deploy documentation step

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -122,3 +122,11 @@ jobs:
           min_instances: 1
           max_instances: 20
           env_vars: OH_HOST=myopenhab.org,OH_PORT=443,OH_PATH=/rest/items/
+
+      - name: Deploy documentation
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.DOCS_REPO_ACCESS_TOKEN }}
+          repository: openhab/openhab-docs
+          event-type: update-openhab-google-assistant-docs-event
+          client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -123,7 +123,8 @@ jobs:
           max_instances: 20
           env_vars: OH_HOST=myopenhab.org,OH_PORT=443,OH_PATH=/rest/items/
 
-      - name: Deploy documentation
+      - name: Update documentation at openhab-docs
+        if: github.event_name == 'release'
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.DOCS_REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
As highlighted in [this forum post](https://community.openhab.org/t/documentation-in-openhab-vs-current-google-assistant-features/140735), the Google Assistant live documentation is not getting updated when a new release is deployed.

This PR adds support for the [fetch external docs workflow](https://github.com/openhab/openhab-docs/pull/1713) added last year to the `openhab-docs` repository to address this specific issue.

The `DOCS_REPO_ACCESS_TOKEN` secret environment variable should already be defined for this repository. If not, @Confectrician should be able to add it.