### PR TITLE
Round numbers to integers where required

### DIFF
--- a/functions/commands/default.js
+++ b/functions/commands/default.js
@@ -26,7 +26,7 @@ class DefaultCommand {
 
   /**
    * Is the requested new state change valid?
-   * @param {string} target Requested target state
+   * @param {string | null} target Requested target state
    * @param {string} state Current state of item
    * @param {object} params Parameters of the command
    * @returns {void} returns if current state is different otherwise throws error
@@ -63,9 +63,10 @@ class DefaultCommand {
    * @param {object} params
    * @param {object} item
    * @param {object} device
+   * @returns {string | null}
    */
   static convertParamsToValue(params, item, device) {
-    return '';
+    return null;
   }
 
   /**
@@ -240,6 +241,7 @@ class DefaultCommand {
           if (shouldCheckState) {
             let currentState = this.getNormalizedState(item);
             if (targetItem !== device.id && item.members && item.members.length) {
+              // @ts-ignore
               const member = item.members.find((m) => m.name === targetItem);
               currentState = member ? this.getNormalizedState(member) : currentState;
             }

--- a/functions/commands/mute.js
+++ b/functions/commands/mute.js
@@ -40,7 +40,7 @@ class Mute extends DefaultCommand {
     }
     let mute = params.mute;
     if (itemType !== 'Switch') {
-      return mute ? '0' : undefined;
+      return mute ? '0' : null;
     }
     if (this.isInverted(device)) {
       mute = !mute;

--- a/functions/devices/charger.js
+++ b/functions/devices/charger.js
@@ -36,9 +36,9 @@ class Charger extends DefaultDevice {
           state.isPluggedIn = members[member].state === 'ON';
           break;
         case 'chargerCapacityRemaining': {
+          const capacity = Math.round(Number(members[member].state));
           if (!config.unit || config.unit === 'PERCENTAGE') {
             let descCapacity = 'UNKNOWN';
-            const capacity = Number(members[member].state);
             if (capacity <= 10) {
               descCapacity = 'CRITICALLY_LOW';
             } else if (capacity <= 40) {
@@ -55,7 +55,7 @@ class Charger extends DefaultDevice {
           state.capacityRemaining = [
             {
               unit: config.unit || 'PERCENTAGE',
-              rawValue: Number(members[member].state)
+              rawValue: capacity
             }
           ];
           break;
@@ -64,7 +64,7 @@ class Charger extends DefaultDevice {
           state.capacityUntilFull = [
             {
               unit: config.unit || 'PERCENTAGE',
-              rawValue: Number(members[member].state)
+              rawValue: Math.round(Number(members[member].state))
             }
           ];
           break;

--- a/functions/devices/colorlight.js
+++ b/functions/devices/colorlight.js
@@ -34,7 +34,7 @@ class ColorLight extends DefaultDevice {
     const [hue, sat, val] = item.state.split(',').map((s) => Number(s.trim()));
     return {
       on: val > 0,
-      brightness: val,
+      brightness: Math.round(val),
       color: {
         spectrumHSV: {
           hue: hue,

--- a/functions/devices/default.js
+++ b/functions/devices/default.js
@@ -8,17 +8,22 @@ class DefaultDevice {
 
   /**
    * @param {object} item
+   * @returns {Array<string>}
    */
   static getTraits(item) {
     return [];
   }
 
+  /**
+   * @returns {Array<string>}
+   */
   static get requiredItemTypes() {
     return [];
   }
 
   /**
    * @param {object} item
+   * @returns {boolean}
    */
   static isCompatible(item) {
     return (

--- a/functions/devices/dimmablelight.js
+++ b/functions/devices/dimmablelight.js
@@ -14,7 +14,7 @@ class DimmableLight extends DefaultDevice {
   }
 
   static getState(item) {
-    let brightness = Number(item.state) || 0;
+    const brightness = Math.round(Number(item.state)) || 0;
     return {
       on: brightness > 0,
       brightness: brightness

--- a/functions/devices/fan.js
+++ b/functions/devices/fan.js
@@ -27,6 +27,7 @@ class Fan extends DefaultDevice {
           .trim()
           .split('=')
           .map((s) => s.trim());
+        // @ts-ignore
         attributes.availableFanSpeeds.speeds.push({
           speed_name: speedName,
           speed_values: [

--- a/functions/devices/speaker.js
+++ b/functions/devices/speaker.js
@@ -33,7 +33,7 @@ class Speaker extends DefaultDevice {
 
   static getState(item) {
     return {
-      currentVolume: Number(item.state) || 0
+      currentVolume: Math.round(Number(item.state)) || 0
     };
   }
 }

--- a/functions/devices/specialcolorlight.js
+++ b/functions/devices/specialcolorlight.js
@@ -54,7 +54,7 @@ class SpecialColorLight extends DefaultDevice {
           state.on = members[member].state === 'ON';
           break;
         case 'lightBrightness':
-          state.brightness = Number(members[member].state) || 0;
+          state.brightness = Math.round(Number(members[member].state)) || 0;
           if (!('lightPower' in members)) {
             state.on = state.brightness > 0;
           }
@@ -83,18 +83,18 @@ class SpecialColorLight extends DefaultDevice {
             const colorUnit = this.getColorUnit(item);
             if (colorUnit === 'kelvin') {
               state.color = {
-                temperatureK: Number(members[member].state)
+                temperatureK: Math.round(Number(members[member].state))
               };
             } else if (colorUnit === 'mired') {
               state.color = {
-                temperatureK: convertMired(Number(members[member].state))
+                temperatureK: convertMired(Math.round(Number(members[member].state)))
               };
             } else {
               const { temperatureMinK, temperatureMaxK } = this.getAttributes(item).colorTemperatureRange;
               state.color = {
                 temperatureK:
                   temperatureMinK +
-                  (((temperatureMaxK - temperatureMinK) / 100) * (100 - Number(members[member].state)) || 0)
+                  (((temperatureMaxK - temperatureMinK) / 100) * (100 - Math.round(Number(members[member].state))) || 0)
               };
             }
           } catch (error) {

--- a/functions/devices/specialcolorlight.js
+++ b/functions/devices/specialcolorlight.js
@@ -94,7 +94,7 @@ class SpecialColorLight extends DefaultDevice {
               state.color = {
                 temperatureK:
                   temperatureMinK +
-                  (((temperatureMaxK - temperatureMinK) / 100) * (100 - Math.round(Number(members[member].state))) || 0)
+                  Math.round(((temperatureMaxK - temperatureMinK) / 100) * (100 - Number(members[member].state)) || 0)
               };
             }
           } catch (error) {

--- a/functions/devices/tv.js
+++ b/functions/devices/tv.js
@@ -112,7 +112,7 @@ class TV extends DefaultDevice {
           state.playbackState = members[member].state;
           break;
         case 'tvVolume':
-          state.currentVolume = Number(members[member].state) || 0;
+          state.currentVolume = Math.round(Number(members[member].state)) || 0;
           break;
         case 'tvChannel':
           state.channelNumber = members[member].state;

--- a/tests/commands/default.test.js
+++ b/tests/commands/default.test.js
@@ -60,7 +60,7 @@ describe('Default Command', () => {
   });
 
   test('convertParamsToValue', () => {
-    expect(Command.convertParamsToValue({}, {}, {})).toBe('');
+    expect(Command.convertParamsToValue({}, {}, {})).toBe(null);
   });
 
   test('getResponseStates', () => {

--- a/tests/commands/mute.test.js
+++ b/tests/commands/mute.test.js
@@ -60,7 +60,7 @@ describe('Mute Command', () => {
   describe('convertParamsToValue', () => {
     test('convertParamsToValue no Switch', () => {
       expect(Command.convertParamsToValue({ mute: true }, {}, {})).toBe('0');
-      expect(Command.convertParamsToValue({ mute: false }, {}, {})).toBeUndefined();
+      expect(Command.convertParamsToValue({ mute: false }, {}, {})).toBe(null);
     });
 
     test('convertParamsToValue Switch', () => {

--- a/tests/devices/charger.test.js
+++ b/tests/devices/charger.test.js
@@ -315,7 +315,7 @@ describe('Charger Device', () => {
           },
           {
             name: 'CapacityRemaining',
-            state: '4000',
+            state: '4000.123',
             metadata: {
               ga: {
                 value: 'chargerCapacityRemaining'
@@ -324,7 +324,7 @@ describe('Charger Device', () => {
           },
           {
             name: 'CapacityUntilFull',
-            state: '6000',
+            state: '6000.123',
             metadata: {
               ga: {
                 value: 'chargerCapacityUntilFull'

--- a/tests/devices/dimmablelight.test.js
+++ b/tests/devices/dimmablelight.test.js
@@ -25,6 +25,10 @@ describe('DimmableLight Device', () => {
       on: true,
       brightness: 50
     });
+    expect(Device.getState({ state: '12.56754' })).toStrictEqual({
+      on: true,
+      brightness: 13
+    });
     expect(Device.getState({ state: 'NULL' })).toStrictEqual({
       on: false,
       brightness: 0

--- a/tests/devices/speaker.test.js
+++ b/tests/devices/speaker.test.js
@@ -63,5 +63,8 @@ describe('Speaker Device', () => {
     expect(Device.getState({ state: '90' })).toStrictEqual({
       currentVolume: 90
     });
+    expect(Device.getState({ state: '23.1234' })).toStrictEqual({
+      currentVolume: 23
+    });
   });
 });

--- a/tests/devices/specialcolorlight.test.js
+++ b/tests/devices/specialcolorlight.test.js
@@ -291,7 +291,7 @@ describe('SpecialColorLight Device', () => {
           ga: {
             value: 'LIGHT',
             config: {
-              colorTemperatureRange: '1000,4000'
+              colorTemperatureRange: '1234,4567'
             }
           }
         },
@@ -305,7 +305,7 @@ describe('SpecialColorLight Device', () => {
             }
           },
           {
-            state: '20',
+            state: '23',
             metadata: {
               ga: {
                 value: 'lightColorTemperature'
@@ -318,7 +318,7 @@ describe('SpecialColorLight Device', () => {
         on: true,
         brightness: 50,
         color: {
-          temperatureK: 3400
+          temperatureK: 3800
         }
       });
     });

--- a/tests/devices/specialcolorlight.test.js
+++ b/tests/devices/specialcolorlight.test.js
@@ -297,7 +297,7 @@ describe('SpecialColorLight Device', () => {
         },
         members: [
           {
-            state: '50',
+            state: '50.421',
             metadata: {
               ga: {
                 value: 'lightBrightness'
@@ -344,7 +344,7 @@ describe('SpecialColorLight Device', () => {
             }
           },
           {
-            state: '2000',
+            state: '2000.345',
             metadata: {
               ga: {
                 value: 'lightColorTemperature'

--- a/tests/devices/tv.test.js
+++ b/tests/devices/tv.test.js
@@ -590,7 +590,7 @@ describe('TV Device', () => {
         },
         members: [
           {
-            state: '50',
+            state: '50.43',
             metadata: {
               ga: {
                 value: 'tvVolume'


### PR DESCRIPTION
With this PR we now round numbers to integers where required by the Google Home API.
So far we just assumed that openHAB does provide integer values for, e.g. brightnesses, volumes or color temperatures.
This seems to not always be the case as stated in #413.

This is now adjusted and state values are rounded.

---

Fixes #413 