### PR TITLE
Add temperatureRange to TemperatureSensor

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -370,10 +370,14 @@ Number capacityFullItem     (chargerGroup) { ga="chargerCapacityUntilFull" }
 | **Device Type** | [Sensor](https://developers.google.com/assistant/smarthome/guides/sensor) |
 | **Supported Traits** | [TemperatureControl](https://developers.google.com/assistant/smarthome/traits/temperaturecontrol) |
 | **Supported Items** | Number |
-| **Configuration** | (optional) `useFahrenheit=true/false` |
+| **Configuration** | (optional) `useFahrenheit=true/false`<br>(optional) `temperatureRange="-10,50"` |
+
+By default the temperature range of a temperature sensor is set to -100°C to 100°C.
+The reported state values have to fall into that range!
+If you need to adjust the range, please add the config option `temperatureRange="-20,40"` to the item. Keep in mind that those values always have to be provided in Celsius!
 
 ```shell
-Number { ga="TemperatureSensor" [ useFahrenheit=true ] }
+Number { ga="TemperatureSensor" [ useFahrenheit=true, temperatureRange="-20,40" ] }
 ```
 
 ### Thermostat
@@ -387,7 +391,7 @@ Number { ga="TemperatureSensor" [ useFahrenheit=true ] }
 
 Thermostat requires a group of items to be properly configured to be used with Google Assistant. The default temperature unit is Celsius.
 To change the temperature unit to Fahrenheit, add the config option `useFahrenheit=true` to the thermostat group.
-To set the temperature range your thermostat supports, add the config option `thermostatTemperatureRange="10,30"` to the thermostat group.
+To set the temperature range your thermostat supports, add the config option `thermostatTemperatureRange="10,30"` to the thermostat group. Those values always have to be provided in Celsius!
 If your thermostat supports a range for the setpoint you can use both `thermostatTemperatureSetpointLow` and `thermostatTemperatureSetpointHigh` instead of the single `thermostatTemperatureSetpoint` item.
 
 If your thermostat does not have a mode, you should create one and manually assign a value (e.g. heat, cool, on, etc.) to have proper functionality.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -372,7 +372,7 @@ Number capacityFullItem     (chargerGroup) { ga="chargerCapacityUntilFull" }
 | **Supported Items** | Number |
 | **Configuration** | (optional) `useFahrenheit=true/false`<br>(optional) `temperatureRange="-10,50"` |
 
-By default the temperature range of a temperature sensor is set to -100°C to 100°C.
+By default, the temperature range of a temperature sensor is set to -100 °C to 100 °C.
 The reported state values have to fall into that range!
 If you need to adjust the range, please add the config option `temperatureRange="-20,40"` to the item. Keep in mind that those values always have to be provided in Celsius!
 

--- a/functions/devices/temperaturesensor.js
+++ b/functions/devices/temperaturesensor.js
@@ -11,10 +11,25 @@ class TemperatureSensor extends DefaultDevice {
   }
 
   static getAttributes(item) {
-    return {
+    const config = this.getConfig(item);
+    const attributes = {
       queryOnlyTemperatureControl: true,
-      temperatureUnitForUX: this.getConfig(item).useFahrenheit === true ? 'F' : 'C'
+      temperatureUnitForUX: config.useFahrenheit === true ? 'F' : 'C',
+      temperatureRange: {
+        minThresholdCelsius: -100,
+        maxThresholdCelsius: 100
+      }
     };
+    if ('temperatureRange' in config) {
+      const [min, max] = config.temperatureRange.split(',').map((s) => parseFloat(s.trim()));
+      if (!isNaN(min) && !isNaN(max)) {
+        attributes.temperatureRange = {
+          minThresholdCelsius: min,
+          maxThresholdCelsius: max
+        };
+      }
+    }
+    return attributes;
   }
 
   static get requiredItemTypes() {

--- a/tests/devices/temperaturesensor.test.js
+++ b/tests/devices/temperaturesensor.test.js
@@ -32,7 +32,11 @@ describe('TemperatureSensor Device', () => {
       };
       expect(Device.getAttributes(item1)).toStrictEqual({
         queryOnlyTemperatureControl: true,
-        temperatureUnitForUX: 'C'
+        temperatureUnitForUX: 'C',
+        temperatureRange: {
+          maxThresholdCelsius: 100,
+          minThresholdCelsius: -100
+        }
       });
     });
 
@@ -48,7 +52,31 @@ describe('TemperatureSensor Device', () => {
       };
       expect(Device.getAttributes(item2)).toStrictEqual({
         queryOnlyTemperatureControl: true,
-        temperatureUnitForUX: 'F'
+        temperatureUnitForUX: 'F',
+        temperatureRange: {
+          maxThresholdCelsius: 100,
+          minThresholdCelsius: -100
+        }
+      });
+    });
+
+    test('getAttributes temperatureRange', () => {
+      const item1 = {
+        metadata: {
+          ga: {
+            config: {
+              temperatureRange: '-20,40'
+            }
+          }
+        }
+      };
+      expect(Device.getAttributes(item1)).toStrictEqual({
+        queryOnlyTemperatureControl: true,
+        temperatureUnitForUX: 'C',
+        temperatureRange: {
+          maxThresholdCelsius: 40,
+          minThresholdCelsius: -20
+        }
       });
     });
   });


### PR DESCRIPTION
As reported in #426, the `TemperatureControl` trait requires the `temperatureRange` attribute.
This was missing so far.

This PR adds this attribute to the `TemperatureSensor` device type.

It also introduces a default range of -100°C to 100°C as a fallback, when no range is provided.

---

Fixes #426

---

TODO:

- [ ] Prepare PR to openhab-ui to add the new attribute