### PR TITLE
Add Climate- & HumiditySensor, Change TemperatureSensor

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -13,6 +13,10 @@ This guide describes step by step how to use the [openHAB Google Assistant Smart
 
 With the Action you can voice control your openHAB items and it supports lights, plugs, switches, thermostats and many more. The openHAB Action comes with multiple language support like English, German or French language.
 
+::: tip Note
+Please be aware that the graphical user interface in the Google Home app or on Google Nest devices may not fully support interaction with some of the supported device types. We cannot influence this and rely on Google to implement user interfaces for more devices. Nevertheless, interaction via voice or in writing with Google Assistant should always work.
+:::
+
 If you have any issues, questions or an idea for additional features, please take a look at the [repository on GitHub](https://github.com/openhab/openhab-google-assistant).
 
 [[toc]]
@@ -42,9 +46,9 @@ More information can be found in the corresponding [docs page](https://www.openh
 
 To expose [items](https://www.openhab.org/docs/concepts/items.html) to Google Assistent you will need to add [metadata](https://www.openhab.org/docs/concepts/items.html#item-metadata) in the `ga` namespace.
 
-Currently the following devices are supported (also depending on Google's API capabilities):
-
 _Hint: The value of `ga` is **not** case-sensitive._
+
+Currently the following devices are supported (also depending on Google's API capabilities):
 
 ### Switch
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -299,7 +299,8 @@ Player transportItem   (tvGroup) { ga="tvTransport" }
 | **Configuration** | (optional) `checkState=true/false`<br>(optional) `speeds="0=away:zero,50=default:standard:one,100=high:two"`<br>(optional) `lang="en"`<br>(optional) `ordered=true/false`<br>_Hint: if you are using a Dimmer then `speeds` is required_ |
 
 Fans (and similar device types, like AirPurifier or Hood) support the `FanSpeed` trait.
-With that you will be able to set up and use human speakable modes, e.g. "fast" for 100% or "slow" for 25%.
+If you do not specify the `speeds` option, Google will use and expect percentage values for the fan speed.
+Otherwise, you will be able to set up and use human speakable modes, e.g. "fast" for 100% or "slow" for 25%.
 
 `speeds` will be a comma-separated list of modes with a percentage number followed by an equal sign and different aliases for that mode after a colon.
 So here both "high" and "two" would set the speed to 100%.
@@ -308,8 +309,8 @@ The option `ordered` will tell the system that your list is ordered and you will
 
 ```shell
 Dimmer { ga="Fan" [ speeds="0=away:zero,50=default:standard:one,100=high:two", lang="en", ordered=true ] }
-Switch { ga="Hood" }
-Dimmer { ga="AirPurifier" [ speeds="0=off,50=mid,100=high" ] }
+Switch { ga="Hood" } # No speed control - only on/off
+Number { ga="AirPurifier" } # Only percentage values for the speed
 ```
 
 ### Awning, Blinds, Curtain, Door, Garage, Gate, Pergola, Shutter, Window
@@ -368,12 +369,40 @@ Number capacityFullItem     (chargerGroup) { ga="chargerCapacityUntilFull" }
 | | |
 |---|---|
 | **Device Type** | [Sensor](https://developers.google.com/assistant/smarthome/guides/sensor) |
-| **Supported Traits** | [TemperatureControl](https://developers.google.com/assistant/smarthome/traits/temperaturecontrol) |
+| **Supported Traits** | [TemperatureSetting](https://developers.google.com/assistant/smarthome/traits/temperaturesetting) |
 | **Supported Items** | Number |
 | **Configuration** | (optional) `useFahrenheit=true/false` |
 
 ```shell
 Number { ga="TemperatureSensor" [ useFahrenheit=true ] }
+```
+
+### HumiditySensor
+
+| | |
+|---|---|
+| **Device Type** | [Sensor](https://developers.google.com/assistant/smarthome/guides/sensor) |
+| **Supported Traits** | [HumiditySetting](https://developers.home.google.com/cloud-to-cloud/traits/humiditysetting) |
+| **Supported Items** | Number |
+| **Configuration** | |
+
+```shell
+Number { ga="HumiditySensor" }
+```
+
+### ClimateSensor
+
+| | |
+|---|---|
+| **Device Type** | [Sensor](https://developers.google.com/assistant/smarthome/guides/sensor) |
+| **Supported Traits** | [HumiditySetting](https://developers.home.google.com/cloud-to-cloud/traits/humiditysetting), [TemperatureSetting](https://developers.google.com/assistant/smarthome/traits/temperaturesetting) |
+| **Supported Items** | Group as `ClimateSensor` with the following members:<br>(optional) Number as `humidityAmbient`<br>(optional) Number as `temperatureAmbient` |
+| **Configuration** | (optional) `useFahrenheit=true/false` |
+
+```shell
+Group  sensorGroup { ga="ClimateSensor" [ useFahrenheit=true ] }
+Number temperatureItem (sensorGroup) { ga="temperatureAmbient" }
+Number humidityItem    (sensorGroup) { ga="humidityAmbient" }
 ```
 
 ### Thermostat
@@ -387,7 +416,7 @@ Number { ga="TemperatureSensor" [ useFahrenheit=true ] }
 
 Thermostat requires a group of items to be properly configured to be used with Google Assistant. The default temperature unit is Celsius.
 To change the temperature unit to Fahrenheit, add the config option `useFahrenheit=true` to the thermostat group.
-To set the temperature range your thermostat supports, add the config option `thermostatTemperatureRange="10,30"` to the thermostat group.
+To set the temperature range your thermostat supports, add the config option `thermostatTemperatureRange="10,30"` to the thermostat group. Those values always have to be provided in Celsius!
 If your thermostat supports a range for the setpoint you can use both `thermostatTemperatureSetpointLow` and `thermostatTemperatureSetpointHigh` instead of the single `thermostatTemperatureSetpoint` item.
 
 If your thermostat does not have a mode, you should create one and manually assign a value (e.g. heat, cool, on, etc.) to have proper functionality.
@@ -401,7 +430,7 @@ However, it is recommended to prefer the `TemperatureSensor` type for simple tem
 
 ```shell
 Group  thermostatGroup { ga="Thermostat" [ modes="off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto", thermostatTemperatureRange="10,30", useFahrenheit=false ] }
-Number ambientItem      (thermostatGroup) { ga="thermostatTemperatureAmbient" }
+Number temperatureItem  (thermostatGroup) { ga="thermostatTemperatureAmbient" }
 Number humidityItem     (thermostatGroup) { ga="thermostatHumidityAmbient" }
 Number setpointItem     (thermostatGroup) { ga="thermostatTemperatureSetpoint" }
 Number setpointItemLow  (thermostatGroup) { ga="thermostatTemperatureSetpointLow" }

--- a/functions/devices/climatesensor.js
+++ b/functions/devices/climatesensor.js
@@ -55,10 +55,7 @@ class ClimateSensor extends DefaultDevice {
   }
 
   static getMembers(item) {
-    const supportedMembers = [
-      'temperatureAmbient',
-      'humidityAmbient'
-    ];
+    const supportedMembers = ['temperatureAmbient', 'humidityAmbient'];
     const members = {};
     if (item.members && item.members.length) {
       item.members.forEach((member) => {

--- a/functions/devices/climatesensor.js
+++ b/functions/devices/climatesensor.js
@@ -1,0 +1,82 @@
+const DefaultDevice = require('./default.js');
+const convertFahrenheitToCelsius = require('../utilities.js').convertFahrenheitToCelsius;
+
+class ClimateSensor extends DefaultDevice {
+  static get type() {
+    return 'action.devices.types.SENSOR';
+  }
+
+  static getTraits(item) {
+    const traits = [];
+    const members = this.getMembers(item);
+    if ('temperatureAmbient' in members) traits.push('action.devices.traits.TemperatureSetting');
+    if ('humidityAmbient' in members) traits.push('action.devices.traits.HumiditySetting');
+    return traits;
+  }
+
+  static getAttributes(item) {
+    const attributes = {};
+    const members = this.getMembers(item);
+    if ('temperatureAmbient' in members) {
+      attributes.queryOnlyTemperatureSetting = true;
+      attributes.thermostatTemperatureUnit = this.useFahrenheit(item) === true ? 'F' : 'C';
+    }
+    if ('humidityAmbient' in members) attributes.queryOnlyHumiditySetting = true;
+    return attributes;
+  }
+
+  static matchesItemType(item) {
+    return item.type === 'Group' && Object.keys(this.getMembers(item)).length > 0;
+  }
+
+  static isCompatible(item = {}) {
+    return (
+      item.metadata &&
+      item.metadata.ga &&
+      item.metadata.ga.value.toLowerCase() == 'climatesensor' &&
+      Object.keys(this.getMembers(item)).length > 0
+    );
+  }
+
+  static getState(item) {
+    const state = {};
+    const members = this.getMembers(item);
+    if ('temperatureAmbient' in members) {
+      let temperature = Number(parseFloat(members['temperatureAmbient'].state).toFixed(1));
+      if (this.useFahrenheit(item)) {
+        temperature = convertFahrenheitToCelsius(temperature);
+      }
+      state.thermostatTemperatureAmbient = temperature;
+    }
+    if ('humidityAmbient' in members) {
+      state.humidityAmbientPercent = Number(parseFloat(members['humidityAmbient'].state).toFixed(1));
+    }
+    return state;
+  }
+
+  static getMembers(item) {
+    const supportedMembers = [
+      'temperatureAmbient',
+      'humidityAmbient'
+    ];
+    const members = {};
+    if (item.members && item.members.length) {
+      item.members.forEach((member) => {
+        if (member.metadata && member.metadata.ga) {
+          const memberType = supportedMembers.find((m) => member.metadata.ga.value.toLowerCase() === m.toLowerCase());
+          if (memberType) {
+            members[memberType] = { name: member.name, state: member.state };
+          }
+        }
+      });
+    }
+    return members;
+  }
+
+  static useFahrenheit(item) {
+    const config = this.getConfig(item);
+    return config.thermostatTemperatureUnit === 'F' || config.useFahrenheit === true;
+  }
+}
+
+module.exports = ClimateSensor;

--- a/functions/devices/humiditysensor.js
+++ b/functions/devices/humiditysensor.js
@@ -1,0 +1,33 @@
+const DefaultDevice = require('./default.js');
+
+class HumiditySensor extends DefaultDevice {
+  static get type() {
+    return 'action.devices.types.SENSOR';
+  }
+
+  static getTraits() {
+    return ['action.devices.traits.HumiditySetting'];
+  }
+
+  static getAttributes() {
+    return {
+      queryOnlyHumiditySetting: true
+    };
+  }
+
+  static get requiredItemTypes() {
+    return ['Number'];
+  }
+
+  static isCompatible(item = {}) {
+    return item.metadata && item.metadata.ga && item.metadata.ga.value.toLowerCase() == 'humiditysensor';
+  }
+
+  static getState(item) {
+    return {
+      humidityAmbientPercent: Number(parseFloat(item.state).toFixed(1))
+    };
+  }
+}
+
+module.exports = HumiditySensor;

--- a/functions/devices/temperaturesensor.js
+++ b/functions/devices/temperaturesensor.js
@@ -7,13 +7,13 @@ class TemperatureSensor extends DefaultDevice {
   }
 
   static getTraits() {
-    return ['action.devices.traits.TemperatureControl'];
+    return ['action.devices.traits.TemperatureSetting'];
   }
 
   static getAttributes(item) {
     return {
-      queryOnlyTemperatureControl: true,
-      temperatureUnitForUX: this.getConfig(item).useFahrenheit === true ? 'F' : 'C'
+      queryOnlyTemperatureSetting: true,
+      thermostatTemperatureUnit: this.useFahrenheit(item) ? 'F' : 'C'
     };
   }
 
@@ -27,13 +27,17 @@ class TemperatureSensor extends DefaultDevice {
 
   static getState(item) {
     let state = Number(parseFloat(item.state).toFixed(1));
-    if (this.getConfig(item).useFahrenheit === true) {
+    if (this.useFahrenheit(item)) {
       state = convertFahrenheitToCelsius(state);
     }
     return {
-      temperatureSetpointCelsius: state,
-      temperatureAmbientCelsius: state
+      thermostatTemperatureAmbient: state
     };
+  }
+
+  static useFahrenheit(item) {
+    const config = this.getConfig(item);
+    return config.thermostatTemperatureUnit === 'F' || config.useFahrenheit === true;
   }
 }
 

--- a/tests/devices/climatesensor.test.js
+++ b/tests/devices/climatesensor.test.js
@@ -1,0 +1,175 @@
+const Device = require('../../functions/devices/climatesensor.js');
+
+describe('ClimateSensor Device', () => {
+  test('isCompatible', () => {
+    expect(
+      Device.isCompatible({
+        metadata: {
+          ga: {
+            value: 'climatesensor'
+          }
+        }
+      })
+    ).toBe(false);
+    expect(
+      Device.isCompatible({
+        metadata: {
+          ga: {
+            value: 'climatesensor'
+          }
+        },
+        members: [
+          {
+            type: 'Number',
+            metadata: {
+              ga: {
+                value: 'temperatureAmbient'
+              }
+            }
+          }
+        ]
+      })
+    ).toBe(true);
+  });
+
+  test('matchesItemType', () => {
+    const item = {
+      type: 'Group',
+      members: [
+        {
+          metadata: {
+            ga: {
+              value: 'temperatureAmbient'
+            }
+          }
+        }
+      ]
+    };
+    expect(Device.matchesItemType({ type: 'Number' })).toBe(false);
+    expect(Device.matchesItemType({ type: 'Number:Temperature' })).toBe(false);
+    expect(Device.matchesItemType({ type: 'Dimmer' })).toBe(false);
+    expect(Device.matchesItemType({ type: 'Group', groupType: 'Number' })).toBe(false);
+    expect(Device.matchesItemType(item)).toBe(true);
+  });
+
+  describe('getAttributes', () => {
+    test('getAttributes no config', () => {
+      const item = {
+        metadata: {
+          ga: {
+            config: {}
+          }
+        }
+      };
+      expect(Device.getAttributes(item)).toStrictEqual({});
+    });
+
+    test('getAttributes humidity', () => {
+      const item = {
+        metadata: {
+          ga: {
+            config: {}
+          }
+        },
+        members: [
+          {
+            name: 'Humidity',
+            state: '60',
+            type: 'Number',
+            metadata: {
+              ga: {
+                value: 'humidityAmbient'
+              }
+            }
+          }
+        ]
+      };
+      expect(Device.getAttributes(item)).toStrictEqual({
+        queryOnlyHumiditySetting: true
+      });
+    });
+
+    test('getAttributes useFahrenheit', () => {
+      const item = {
+        metadata: {
+          ga: {
+            config: {
+              useFahrenheit: true
+            }
+          }
+        },
+        members: [
+          {
+            name: 'Temperature',
+            state: '20',
+            type: 'Number',
+            metadata: {
+              ga: {
+                value: 'temperatureAmbient'
+              }
+            }
+          }
+        ]
+      };
+      expect(Device.getAttributes(item)).toStrictEqual({
+        queryOnlyTemperatureSetting: true,
+        thermostatTemperatureUnit: 'F'
+      });
+    });
+  });
+
+  test('getState', () => {
+    const item1 = {
+      members: [
+        {
+          name: 'Temperature',
+          state: '20',
+          type: 'Number',
+          metadata: {
+            ga: {
+              value: 'temperatureAmbient'
+            }
+          }
+        },
+        {
+          name: 'Humidity',
+          state: '60',
+          type: 'Number',
+          metadata: {
+            ga: {
+              value: 'humidityAmbient'
+            }
+          }
+        }
+      ]
+    };
+    expect(Device.getState(item1)).toStrictEqual({
+      thermostatTemperatureAmbient: 20,
+      humidityAmbientPercent: 60
+    });
+    const item2 = {
+      members: [
+        {
+          name: 'Temperature',
+          state: '10',
+          type: 'Number',
+          metadata: {
+            ga: {
+              value: 'temperatureAmbient'
+            }
+          }
+        }
+      ],
+      metadata: {
+        ga: {
+          config: {
+            useFahrenheit: true
+          }
+        }
+      }
+    };
+    expect(Device.getState(item2)).toStrictEqual({
+      thermostatTemperatureAmbient: -12.2
+    });
+  });
+});

--- a/tests/devices/humiditysensor.test.js
+++ b/tests/devices/humiditysensor.test.js
@@ -1,0 +1,37 @@
+const Device = require('../../functions/devices/humiditysensor.js');
+
+describe('HumiditySensor Device', () => {
+  test('isCompatible', () => {
+    expect(
+      Device.isCompatible({
+        metadata: {
+          ga: {
+            value: 'humiditysensor'
+          }
+        }
+      })
+    ).toBe(true);
+  });
+
+  test('matchesItemType', () => {
+    expect(Device.matchesItemType({ type: 'Number' })).toBe(true);
+    expect(Device.matchesItemType({ type: 'Number:Humidity' })).toBe(true);
+    expect(Device.matchesItemType({ type: 'Dimmer' })).toBe(false);
+    expect(Device.matchesItemType({ type: 'Group', groupType: 'Dimmer' })).toBe(false);
+    expect(Device.matchesItemType({ type: 'Group', groupType: 'Number' })).toBe(true);
+  });
+
+  describe('getAttributes', () => {
+    test('getAttributes no config', () => {
+      expect(Device.getAttributes()).toStrictEqual({
+        queryOnlyHumiditySetting: true
+      });
+    });
+  });
+
+  test('getState', () => {
+    expect(Device.getState({ state: '10' })).toStrictEqual({
+      humidityAmbientPercent: 10
+    });
+  });
+});

--- a/tests/devices/temperaturesensor.test.js
+++ b/tests/devices/temperaturesensor.test.js
@@ -23,21 +23,21 @@ describe('TemperatureSensor Device', () => {
 
   describe('getAttributes', () => {
     test('getAttributes no config', () => {
-      const item1 = {
+      const item = {
         metadata: {
           ga: {
             config: {}
           }
         }
       };
-      expect(Device.getAttributes(item1)).toStrictEqual({
-        queryOnlyTemperatureControl: true,
-        temperatureUnitForUX: 'C'
+      expect(Device.getAttributes(item)).toStrictEqual({
+        queryOnlyTemperatureSetting: true,
+        thermostatTemperatureUnit: 'C'
       });
     });
 
     test('getAttributes useFahrenheit', () => {
-      const item2 = {
+      const item = {
         metadata: {
           ga: {
             config: {
@@ -46,17 +46,16 @@ describe('TemperatureSensor Device', () => {
           }
         }
       };
-      expect(Device.getAttributes(item2)).toStrictEqual({
-        queryOnlyTemperatureControl: true,
-        temperatureUnitForUX: 'F'
+      expect(Device.getAttributes(item)).toStrictEqual({
+        queryOnlyTemperatureSetting: true,
+        thermostatTemperatureUnit: 'F'
       });
     });
   });
 
   test('getState', () => {
     expect(Device.getState({ state: '10' })).toStrictEqual({
-      temperatureSetpointCelsius: 10,
-      temperatureAmbientCelsius: 10
+      thermostatTemperatureAmbient: 10
     });
     const item = {
       state: '10',
@@ -69,8 +68,7 @@ describe('TemperatureSensor Device', () => {
       }
     };
     expect(Device.getState(item)).toStrictEqual({
-      temperatureSetpointCelsius: -12.2,
-      temperatureAmbientCelsius: -12.2
+      thermostatTemperatureAmbient: -12.2
     });
   });
 });


### PR DESCRIPTION
While working on #426, we noticed that using `TemperatureControl` does not show any UI for the sensor in the Google Home app.
Apparently, using the `TemperatureSetting` trait does the trick.
Therefore, I adjusted the `TemperatureSensor` to use the other trait.
In addition to that, I added a `HumiditySensor` (only for humidity) and a `ClimateSensor` (for both humidity and temperature).

This supersedes #428 as working with ranges did not fix the issue.

![Screenshot_20230103-212322](https://user-images.githubusercontent.com/727517/210435706-0abc3d78-3e25-4e80-8de4-0d9bb0d82016.jpg)
![Screenshot_20230103-212333](https://user-images.githubusercontent.com/727517/210435709-b4552663-bcff-4eb3-8560-d6d6c2ae4ca9.jpg)
![Screenshot_20230103-212339](https://user-images.githubusercontent.com/727517/210435713-505faa05-881a-41a9-81a3-276a853a906c.jpg)


---

Resolves #426
Resolves #427

---

ToDo

- [x] Prepare PR for openhab-webui to add the new annotations