### PR TITLE
Return Humidity states as Integer

### DIFF
--- a/functions/devices/climatesensor.js
+++ b/functions/devices/climatesensor.js
@@ -56,7 +56,7 @@ class ClimateSensor extends DefaultDevice {
       state.temperatureSetpointCelsius = temperature;
     }
     if ('humidityAmbient' in members) {
-      const humidity = Number(parseFloat(members.humidityAmbient.state).toFixed(1));
+      const humidity = Math.round(Number(members.humidityAmbient.state));
       state.humidityAmbientPercent = humidity;
       state.humiditySetpointPercent = humidity;
     }

--- a/functions/devices/humiditysensor.js
+++ b/functions/devices/humiditysensor.js
@@ -24,7 +24,7 @@ class HumiditySensor extends DefaultDevice {
   }
 
   static getState(item) {
-    const state = Number(parseFloat(item.state).toFixed(1));
+    const state = Math.round(Number(item.state));
     return {
       humidityAmbientPercent: state,
       humiditySetpointPercent: state

--- a/tests/devices/climatesensor.test.js
+++ b/tests/devices/climatesensor.test.js
@@ -135,7 +135,7 @@ describe('ClimateSensor Device', () => {
         },
         {
           name: 'Humidity',
-          state: '60',
+          state: '59.7',
           type: 'Number',
           metadata: {
             ga: {
@@ -182,7 +182,7 @@ describe('ClimateSensor Device', () => {
       members: [
         {
           name: 'Humidity',
-          state: '30',
+          state: '30.3',
           type: 'Number',
           metadata: {
             ga: {

--- a/tests/devices/humiditysensor.test.js
+++ b/tests/devices/humiditysensor.test.js
@@ -30,7 +30,7 @@ describe('HumiditySensor Device', () => {
   });
 
   test('getState', () => {
-    expect(Device.getState({ state: '10' })).toStrictEqual({
+    expect(Device.getState({ state: '10.3' })).toStrictEqual({
       humidityAmbientPercent: 10,
       humiditySetpointPercent: 10
     });


### PR DESCRIPTION
As reported by multiple users, the humidity sensor feature is not working properly.
After some investigations, I discovered that Google requires Integers values while the current implementations returns floating point numbers.

With this PR both the ClimateSensor and HumiditySensor are returning Integer values for the humidity.

---

Should fix #448 