### PR TITLE
Adjust Fan to use supportsFanSpeedPercent option

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -307,7 +307,7 @@ Player transportItem   (tvGroup) { ga="tvTransport" }
 | **Device Type** | [Fan](https://developers.home.google.com/cloud-to-cloud/guides/fan), [Hood](https://developers.home.google.com/cloud-to-cloud/guides/hood), [AirPurifier](https://developers.home.google.com/cloud-to-cloud/guides/airpurifier) |
 | **Supported Traits** | [OnOff](https://developers.home.google.com/cloud-to-cloud/traits/OnOff), [FanSpeed](https://developers.home.google.com/cloud-to-cloud/traits/fanspeed) (depending on used item type) |
 | **Supported Items** | Switch (no speed control), Dimmer |
-| **Configuration** | (optional) `checkState=true/false`<br>(optional) `speeds="0=away:zero,50=default:standard:one,100=high:two"`<br>(optional) `lang="en"`<br>(optional) `ordered=true/false`<br>_Hint: if you are using a Dimmer then `speeds` is required_ |
+| **Configuration** | (optional) `checkState=true/false`<br>(optional) `speeds="0=away:zero,50=default:standard:one,100=high:two"`<br>(optional) `lang="en"`<br>(optional) `ordered=true/false` |
 
 Fans (and similar device types, like AirPurifier or Hood) support the `FanSpeed` trait.
 If you do not specify the `speeds` option, Google will use and expect percentage values for the fan speed.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -320,10 +320,10 @@ You are also able to define the language of those aliases.
 The option `ordered` will tell the system that your list is ordered and you will then be able to also say "faster" or "slower" and Google will use the next or previous speed.
 
 ```shell
-Dimmer { ga="Fan" [ speeds="0=away:zero,50=default:standard:one,100=high:two", lang="en", ordered=true ] } # Only percentage values for the speed
+Dimmer { ga="Fan" [ speeds="0=away:zero,50=default:standard:one,100=high:two", lang="en", ordered=true ] } # Using specific percentage values for the speed
 Switch { ga="Hood" } # No speed control - only on/off
-Dimmer { ga="AirPurifier" } # Only percentage values for the speed
-Dimmer { ga="AirPurifier" [ speeds="0=away:zero,1=low:one,2=medium:two,3=high:three,4=turbo:four", lang="en", ordered=true ] } # Specific speed modes/values stated, which can differ from percentage
+Dimmer { ga="AirPurifier" } # Using percentage values for the speed
+Dimmer { ga="AirPurifier" [ speeds="0=away:zero,1=low:one,2=medium:two,3=high:three,4=turbo:four", lang="en", ordered=true ] } # Using specific speed modes/values, which differ from percentage
 Switch { ga="AirPurifier" } # No speed control - only on/off
 ```
 

--- a/functions/commands/setfanspeedpercent.js
+++ b/functions/commands/setfanspeedpercent.js
@@ -1,0 +1,23 @@
+const DefaultCommand = require('./default.js');
+
+class SetFanSpeedPercent extends DefaultCommand {
+  static get type() {
+    return 'action.devices.commands.SetFanSpeed';
+  }
+
+  static validateParams(params) {
+    return 'fanSpeedPercent' in params && typeof params.fanSpeedPercent === 'number';
+  }
+
+  static convertParamsToValue(params) {
+    return params.fanSpeedPercent.toString();
+  }
+
+  static getResponseStates(params) {
+    return {
+      currentFanSpeedPercent: params.fanSpeedPercent
+    };
+  }
+}
+
+module.exports = SetFanSpeedPercent;

--- a/functions/devices/fan.js
+++ b/functions/devices/fan.js
@@ -51,10 +51,16 @@ class Fan extends DefaultDevice {
   }
 
   static getState(item) {
-    return {
-      currentFanSpeedSetting: item.state.toString(),
+    const state = {
       on: Number(item.state) > 0
     };
+    const config = this.getConfig(item);
+    if (config && config.speeds) {
+      state.currentFanSpeedSetting = item.state.toString();
+    } else {
+      state.currentFanSpeedPercent = Math.round(Number(item.state));
+    }
+    return state;
   }
 }
 

--- a/functions/devices/fan.js
+++ b/functions/devices/fan.js
@@ -12,7 +12,9 @@ class Fan extends DefaultDevice {
   static getAttributes(item) {
     const config = this.getConfig(item);
     if (!config || !config.speeds) {
-      return {};
+      return {
+        supportsFanSpeedPercent: true
+      };
     }
     const attributes = {
       availableFanSpeeds: {

--- a/tests/commands/setfanspeedpercent.test.js
+++ b/tests/commands/setfanspeedpercent.test.js
@@ -1,0 +1,18 @@
+const Command = require('../../functions/commands/setfanspeedpercent.js');
+
+describe('SetFanSpeed Command', () => {
+  const params = { fanSpeedPercent: 50 };
+
+  test('validateParams', () => {
+    expect(Command.validateParams({})).toBe(false);
+    expect(Command.validateParams(params)).toBe(true);
+  });
+
+  test('convertParamsToValue', () => {
+    expect(Command.convertParamsToValue(params)).toBe('50');
+  });
+
+  test('getResponseStates', () => {
+    expect(Command.getResponseStates(params)).toStrictEqual({ currentFanSpeedPercent: 50 });
+  });
+});

--- a/tests/devices/fan.test.js
+++ b/tests/devices/fan.test.js
@@ -86,6 +86,23 @@ describe('Fan Device', () => {
 
   test('getState', () => {
     expect(Device.getState({ state: '50' })).toStrictEqual({
+      currentFanSpeedPercent: 50,
+      on: true
+    });
+    expect(
+      Device.getState({
+        state: '50',
+        metadata: {
+          ga: {
+            config: {
+              ordered: true,
+              speeds: '0=null:off,50=slow,100=full:fast',
+              lang: 'en'
+            }
+          }
+        }
+      })
+    ).toStrictEqual({
       currentFanSpeedSetting: '50',
       on: true
     });

--- a/tests/devices/fan.test.js
+++ b/tests/devices/fan.test.js
@@ -29,7 +29,9 @@ describe('Fan Device', () => {
           }
         }
       };
-      expect(Device.getAttributes(item)).toStrictEqual({});
+      expect(Device.getAttributes(item)).toStrictEqual({
+        supportsFanSpeedPercent: true
+      });
     });
 
     test('getAttributes speeds', () => {


### PR DESCRIPTION
As stated in https://developers.home.google.com/cloud-to-cloud/traits/fanspeed#device-attributes there is now a new option called `supportsFanSpeedPercent` that should be set to true if no speeds are defined.

This PR adds this option in case the devices is coming from a `Dimmer` item and does not provide a `speeds` config.

To actually set the speed in percent, the new command SetFanSpeed with the parameter `fanSpeedPercent` is added.

This is also reflected in the state reporting that now either reports the percentage or settings value.