### PR TITLE
Invert color temperature percentage range

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -94,7 +94,7 @@ Color  { ga="Light" [ colorTemperatureRange="2000,9000" ] }
 | **Device Type** | [Light](https://developers.home.google.com/cloud-to-cloud/guides/light) |
 | **Supported Traits** | [OnOff](https://developers.home.google.com/cloud-to-cloud/traits/onoff), [ColorSetting](https://developers.home.google.com/cloud-to-cloud/traits/colorsetting), [Brightness](https://developers.home.google.com/cloud-to-cloud/traits/brightness) |
 | **Supported Items** | Group as `SpecialColorLight` with the following members:<br>(optional) Number or Dimmer as `lightBrightness`<br>(optional) Number or Dimmer as `lightColorTemperature`<br>(optional) Color as `lightColor`<br>(optional) Switch as `lightPower` |
-| **Configuration** | (optional) `colorUnit=percent/kelvin/mired`<br>(optional) `checkState=true/false`<br>(optional) `colorTemperatureRange="minK,maxK"`<br>_Hint: if you want to use `lightColorTemperature` you either need to set `colorUnit` to `kelvin` or `mired` or define a `colorTemperatureRange` as `colorUnit` defaults to `percent`_ |
+| **Configuration** | (optional) `colorUnit=percent/kelvin/mired`<br>(optional) `checkState=true/false`<br>(optional) `colorTemperatureRange="minK,maxK"`<br>_Hint: if you want to use `lightColorTemperature`, you must either set `colorUnit` to `kelvin` or `mired` or define a `colorTemperatureRange`, because `colorUnit` defaults to `percent`_ |
 
 ```shell
 Group  lightGroup { ga="SpecialColorLight" [ colorUnit="kelvin", colorTemperatureRange="2000,9000" ] }

--- a/functions/commands/colorabsolutetemperature.js
+++ b/functions/commands/colorabsolutetemperature.js
@@ -42,10 +42,7 @@ class ColorAbsoluteTemperature extends DefaultCommand {
           return convertMired(params.color.temperature).toString();
         }
         const { temperatureMinK, temperatureMaxK } = SpecialColorLight.getAttributes(item).colorTemperatureRange;
-        return (
-          100 -
-          ((params.color.temperature - temperatureMinK) / (temperatureMaxK - temperatureMinK)) * 100
-        ).toString();
+        return (((params.color.temperature - temperatureMinK) / (temperatureMaxK - temperatureMinK)) * 100).toString();
       } catch (error) {
         return '0';
       }

--- a/functions/devices/specialcolorlight.js
+++ b/functions/devices/specialcolorlight.js
@@ -94,7 +94,7 @@ class SpecialColorLight extends DefaultDevice {
               state.color = {
                 temperatureK:
                   temperatureMinK +
-                  Math.round(((temperatureMaxK - temperatureMinK) / 100) * (100 - Number(members[member].state)) || 0)
+                  Math.round(((temperatureMaxK - temperatureMinK) / 100) * Number(members[member].state) || 0)
               };
             }
           } catch (error) {

--- a/tests/commands/colorabsolutetemperature.test.js
+++ b/tests/commands/colorabsolutetemperature.test.js
@@ -54,7 +54,7 @@ describe('ColorAbsoluteTemperature Command', () => {
         }
       };
       const device = { customData: { deviceType: 'SpecialColorLight' } };
-      expect(Command.convertParamsToValue(params, item, device)).toBe('75');
+      expect(Command.convertParamsToValue(params, item, device)).toBe('25');
       expect(Command.convertParamsToValue(params, { state: '100,100,50' }, device)).toBe('0');
     });
 

--- a/tests/devices/specialcolorlight.test.js
+++ b/tests/devices/specialcolorlight.test.js
@@ -305,7 +305,7 @@ describe('SpecialColorLight Device', () => {
             }
           },
           {
-            state: '23',
+            state: '77',
             metadata: {
               ga: {
                 value: 'lightColorTemperature'
@@ -422,7 +422,7 @@ describe('SpecialColorLight Device', () => {
             }
           },
           {
-            state: '20',
+            state: '80',
             metadata: {
               ga: {
                 value: 'lightColorTemperature'
@@ -469,7 +469,7 @@ describe('SpecialColorLight Device', () => {
             }
           },
           {
-            state: '20',
+            state: '80',
             metadata: {
               ga: {
                 value: 'lightColorTemperature'
@@ -567,7 +567,7 @@ describe('SpecialColorLight Device', () => {
             }
           },
           {
-            state: '20',
+            state: '80',
             metadata: {
               ga: {
                 value: 'lightColorTemperature'


### PR DESCRIPTION
As mentioned at https://community.openhab.org/t/oh3-color-light-bulb-and-google-assistant/129938/7, there is some confusion about the relationship between color temperatures and their percentage equivalent.

In the current implementation, the percent values are inverted before conversion to Kelvin. I honestly don't know why this was implemented this way.

To make this more intuitive, we remove the inversion and reflect low kelvin values to low percent values and vice versa.