### PR TITLE
Add colorTemperatureInverted option

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -99,7 +99,12 @@ Color  { ga="Light" [ colorTemperatureRange="2000,9000" ] }
 | **Device Type** | [Light](https://developers.home.google.com/cloud-to-cloud/guides/light) |
 | **Supported Traits** | [OnOff](https://developers.home.google.com/cloud-to-cloud/traits/onoff), [ColorSetting](https://developers.home.google.com/cloud-to-cloud/traits/colorsetting), [Brightness](https://developers.home.google.com/cloud-to-cloud/traits/brightness) |
 | **Supported Items** | Group as `SpecialColorLight` with the following members:<br>(optional) Number or Dimmer as `lightBrightness`<br>(optional) Number or Dimmer as `lightColorTemperature`<br>(optional) Color as `lightColor`<br>(optional) Switch as `lightPower` |
-| **Configuration** | (optional) `colorUnit="percent/kelvin/mired"`<br>(optional) `checkState=true/false`<br>(optional) `colorTemperatureRange="minK,maxK"`<br>_Hint: if you want to use `lightColorTemperature`, you must either set `colorUnit` to `kelvin` or `mired` or define a `colorTemperatureRange`, because `colorUnit` defaults to `percent`_ |
+| **Configuration** | (optional) `colorUnit="percent/kelvin/mired"`<br>(optional) `checkState=true/false`<br>(optional) `colorTemperatureRange="minK,maxK"`<br>(optional) `colorTemperatureInverted=true/false` |
+
+**Important Hint:** If you want to use `lightColorTemperature`, you must either set `colorUnit` to `kelvin` or `mired` or define a `colorTemperatureRange`, because `colorUnit` defaults to `percent`.
+
+If you use `colorUnit` as percentage values, the lowest color temperature (warm light) will be converted to 0%, and correspondingly the highest color temperature (cold light) will be converted to 100%.
+If you need the inverted values for your device, you can set `colorTemperatureInverted=true`. This will convert low Kelvin values to high percentage values and vice versa.
 
 ```shell
 Group  lightGroup { ga="SpecialColorLight" [ colorUnit="kelvin", colorTemperatureRange="2000,9000" ] }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -114,6 +114,14 @@ Color  colorItem            (lightGroup) { ga="lightColor" }
 Number colorTemperatureItem (lightGroup) { ga="lightColorTemperature" }
 ```
 
+Example of a light device where low Kelvin values (warm light) are represented by high percentage values in the color temperature item:
+
+```shell
+Group  lightGroup { ga="SpecialColorLight" [ colorUnit="percent", colorTemperatureRange="2000,6500", colorTemperatureInverted=true ] }
+Dimmer brightnessItem       (lightGroup) { ga="lightBrightness" }
+Dimmer colorTemperatureItem (lightGroup) { ga="lightColorTemperature" }
+```
+
 In case you want to control multiple lights using one device with Google Assistant, you can apply the following pattern:
 
 ```shell

--- a/functions/commands/colorabsolutetemperature.js
+++ b/functions/commands/colorabsolutetemperature.js
@@ -42,7 +42,11 @@ class ColorAbsoluteTemperature extends DefaultCommand {
           return convertMired(params.color.temperature).toString();
         }
         const { temperatureMinK, temperatureMaxK } = SpecialColorLight.getAttributes(item).colorTemperatureRange;
-        return (((params.color.temperature - temperatureMinK) / (temperatureMaxK - temperatureMinK)) * 100).toString();
+        let percent = ((params.color.temperature - temperatureMinK) / (temperatureMaxK - temperatureMinK)) * 100;
+        if (SpecialColorLight.getColorTemperatureInverted(item)) {
+          percent = 100 - percent;
+        }
+        return percent.toString();
       } catch (error) {
         return '0';
       }

--- a/functions/devices/default.js
+++ b/functions/devices/default.js
@@ -93,13 +93,13 @@ class DefaultDevice {
         itemType: itemType
       }
     };
-    if (config.inverted === true) {
+    if (!!config.inverted === true) {
       metadata.customData.inverted = true;
     }
-    if (config.checkState === true) {
+    if (!!config.checkState === true) {
       metadata.customData.checkState = true;
     }
-    if (config.ackNeeded === true || config.tfaAck === true) {
+    if (!!config.ackNeeded === true || !!config.tfaAck === true) {
       metadata.customData.ackNeeded = true;
     }
     if (typeof config.pinNeeded === 'string' || typeof config.tfaPin === 'string') {

--- a/functions/devices/specialcolorlight.js
+++ b/functions/devices/specialcolorlight.js
@@ -91,10 +91,12 @@ class SpecialColorLight extends DefaultDevice {
               };
             } else {
               const { temperatureMinK, temperatureMaxK } = this.getAttributes(item).colorTemperatureRange;
+              let percent = Number(members[member].state);
+              if (this.getColorTemperatureInverted(item)) {
+                percent = 100 - percent;
+              }
               state.color = {
-                temperatureK:
-                  temperatureMinK +
-                  Math.round(((temperatureMaxK - temperatureMinK) / 100) * Number(members[member].state) || 0)
+                temperatureK: temperatureMinK + Math.round(((temperatureMaxK - temperatureMinK) / 100) * percent || 0)
               };
             }
           } catch (error) {
@@ -125,6 +127,10 @@ class SpecialColorLight extends DefaultDevice {
   static getColorUnit(item) {
     const colorUnit = this.getConfig(item).colorUnit || 'percent';
     return colorUnit.toLowerCase();
+  }
+
+  static getColorTemperatureInverted(item) {
+    return !!this.getConfig(item).colorTemperatureInverted === true;
   }
 }
 

--- a/tests/commands/colorabsolutetemperature.test.js
+++ b/tests/commands/colorabsolutetemperature.test.js
@@ -85,6 +85,21 @@ describe('ColorAbsoluteTemperature Command', () => {
       const device = { customData: { deviceType: 'SpecialColorLight' } };
       expect(Command.convertParamsToValue(params, item, device)).toBe('500');
     });
+
+    test('convertParamsToValue SpecialColorLight Percent Inverted', () => {
+      const item = {
+        metadata: {
+          ga: {
+            config: {
+              colorTemperatureRange: '1000,5000',
+              colorTemperatureInverted: true
+            }
+          }
+        }
+      };
+      const device = { customData: { deviceType: 'SpecialColorLight' } };
+      expect(Command.convertParamsToValue(params, item, device)).toBe('75');
+    });
   });
 
   test('getResponseStates', () => {

--- a/tests/devices/specialcolorlight.test.js
+++ b/tests/devices/specialcolorlight.test.js
@@ -336,14 +336,6 @@ describe('SpecialColorLight Device', () => {
         },
         members: [
           {
-            state: '50',
-            metadata: {
-              ga: {
-                value: 'lightBrightness'
-              }
-            }
-          },
-          {
             state: '2000.345',
             metadata: {
               ga: {
@@ -354,10 +346,39 @@ describe('SpecialColorLight Device', () => {
         ]
       };
       expect(Device.getState(item)).toStrictEqual({
-        on: true,
-        brightness: 50,
         color: {
           temperatureK: 2000
+        }
+      });
+    });
+
+    test('getState percent inverted', () => {
+      const item = {
+        type: 'Group',
+        metadata: {
+          ga: {
+            value: 'LIGHT',
+            config: {
+              colorTemperatureRange: '2000,5000',
+              colorTemperatureInverted: true
+            }
+          }
+        },
+        members: [
+          {
+            state: '25',
+            type: 'Number',
+            metadata: {
+              ga: {
+                value: 'lightColorTemperature'
+              }
+            }
+          }
+        ]
+      };
+      expect(Device.getState(item)).toStrictEqual({
+        color: {
+          temperatureK: 4250
         }
       });
     });
@@ -375,14 +396,6 @@ describe('SpecialColorLight Device', () => {
         },
         members: [
           {
-            state: '50',
-            metadata: {
-              ga: {
-                value: 'lightBrightness'
-              }
-            }
-          },
-          {
             state: '200',
             metadata: {
               ga: {
@@ -393,8 +406,6 @@ describe('SpecialColorLight Device', () => {
         ]
       };
       expect(Device.getState(item)).toStrictEqual({
-        on: true,
-        brightness: 50,
         color: {
           temperatureK: 5000
         }


### PR DESCRIPTION
Add new configuration option `colorTemperatureInverted` to `SpecialColorLight`

This will enable users to connect devices with color temperature Dimmer channels that expect low values for cold colors to invert the default conversion logic.

Example of a light device where low Kelvin values (warm light) are represented by high percentage values in the color temperature item:

```
Group  lightGroup { ga="SpecialColorLight" [ colorUnit="percent", colorTemperatureRange="2000,6500", colorTemperatureInverted=true ] }
Dimmer brightnessItem       (lightGroup) { ga="lightBrightness" }
Dimmer colorTemperatureItem (lightGroup) { ga="lightColorTemperature" }
```