### PR TITLE
Parse states as float for Number:Dimensionless items with units

### DIFF
--- a/functions/devices/charger.js
+++ b/functions/devices/charger.js
@@ -36,7 +36,7 @@ class Charger extends DefaultDevice {
           state.isPluggedIn = members[member].state === 'ON';
           break;
         case 'chargerCapacityRemaining': {
-          const capacity = Math.round(Number(members[member].state));
+          const capacity = Math.round(parseFloat(members[member].state));
           if (!config.unit || config.unit === 'PERCENTAGE') {
             let descCapacity = 'UNKNOWN';
             if (capacity <= 10) {
@@ -64,7 +64,7 @@ class Charger extends DefaultDevice {
           state.capacityUntilFull = [
             {
               unit: config.unit || 'PERCENTAGE',
-              rawValue: Math.round(Number(members[member].state))
+              rawValue: Math.round(parseFloat(members[member].state))
             }
           ];
           break;

--- a/functions/devices/climatesensor.js
+++ b/functions/devices/climatesensor.js
@@ -56,7 +56,7 @@ class ClimateSensor extends DefaultDevice {
       state.temperatureSetpointCelsius = temperature;
     }
     if ('humidityAmbient' in members) {
-      const humidity = Math.round(Number(members.humidityAmbient.state));
+      const humidity = Math.round(parseFloat(members.humidityAmbient.state));
       state.humidityAmbientPercent = humidity;
       state.humiditySetpointPercent = humidity;
     }

--- a/functions/devices/dimmablelight.js
+++ b/functions/devices/dimmablelight.js
@@ -14,7 +14,7 @@ class DimmableLight extends DefaultDevice {
   }
 
   static getState(item) {
-    const brightness = Math.round(Number(item.state)) || 0;
+    const brightness = Math.round(parseFloat(item.state)) || 0;
     return {
       on: brightness > 0,
       brightness: brightness

--- a/functions/devices/fan.js
+++ b/functions/devices/fan.js
@@ -51,14 +51,15 @@ class Fan extends DefaultDevice {
   }
 
   static getState(item) {
+    const itemState = Math.round(parseFloat(item.state));
     const state = {
-      on: Number(item.state) > 0
+      on: itemState > 0
     };
     const config = this.getConfig(item);
     if (config && config.speeds) {
-      state.currentFanSpeedSetting = item.state.toString();
+      state.currentFanSpeedSetting = itemState.toString();
     } else {
-      state.currentFanSpeedPercent = Math.round(Number(item.state));
+      state.currentFanSpeedPercent = itemState;
     }
     return state;
   }

--- a/functions/devices/humiditysensor.js
+++ b/functions/devices/humiditysensor.js
@@ -24,7 +24,7 @@ class HumiditySensor extends DefaultDevice {
   }
 
   static getState(item) {
-    const state = Math.round(Number(item.state));
+    const state = Math.round(parseFloat(item.state));
     return {
       humidityAmbientPercent: state,
       humiditySetpointPercent: state

--- a/functions/devices/openclosedevice.js
+++ b/functions/devices/openclosedevice.js
@@ -30,7 +30,7 @@ class OpenCloseDevice extends DefaultDevice {
     let state = 0;
     const itemType = item.groupType || item.type;
     if (itemType === 'Rollershutter') {
-      state = Number(item.state);
+      state = Math.round(parseFloat(item.state));
     } else {
       state = item.state === 'ON' || item.state === 'OPEN' ? 0 : 100;
     }

--- a/functions/devices/sensor.js
+++ b/functions/devices/sensor.js
@@ -32,15 +32,17 @@ class Sensor extends DefaultDevice {
 
   static getState(item) {
     const config = this.getConfig(item);
-    return {
+    const state = {
       currentSensorStateData: [
         {
           name: config.sensorName,
-          currentSensorState: this.translateStateToGoogle(item),
-          rawValue: Number(item.state) || 0
+          currentSensorState: this.translateStateToGoogle(item)
         }
       ]
     };
+    const rawValue = parseFloat(item.state);
+    if (!isNaN(rawValue)) state.currentSensorStateData[0].rawValue = rawValue;
+    return state;
   }
 
   static translateStateToGoogle(item) {
@@ -49,7 +51,7 @@ class Sensor extends DefaultDevice {
       const states = config.states.split(',').map((s) => s.trim());
       for (const state of states) {
         const [key, value] = state.split('=').map((s) => s.trim());
-        if (value == item.state) {
+        if (value === item.state || value === parseFloat(item.state).toFixed(0)) {
           return key;
         }
       }

--- a/functions/devices/speaker.js
+++ b/functions/devices/speaker.js
@@ -33,7 +33,7 @@ class Speaker extends DefaultDevice {
 
   static getState(item) {
     return {
-      currentVolume: Math.round(Number(item.state)) || 0
+      currentVolume: Math.round(parseFloat(item.state)) || 0
     };
   }
 }

--- a/functions/devices/specialcolorlight.js
+++ b/functions/devices/specialcolorlight.js
@@ -54,7 +54,7 @@ class SpecialColorLight extends DefaultDevice {
           state.on = members[member].state === 'ON';
           break;
         case 'lightBrightness':
-          state.brightness = Math.round(Number(members[member].state)) || 0;
+          state.brightness = Math.round(parseFloat(members[member].state)) || 0;
           if (!('lightPower' in members)) {
             state.on = state.brightness > 0;
           }
@@ -83,15 +83,15 @@ class SpecialColorLight extends DefaultDevice {
             const colorUnit = this.getColorUnit(item);
             if (colorUnit === 'kelvin') {
               state.color = {
-                temperatureK: Math.round(Number(members[member].state))
+                temperatureK: Math.round(parseFloat(members[member].state))
               };
             } else if (colorUnit === 'mired') {
               state.color = {
-                temperatureK: convertMired(Math.round(Number(members[member].state)))
+                temperatureK: convertMired(Math.round(parseFloat(members[member].state)))
               };
             } else {
               const { temperatureMinK, temperatureMaxK } = this.getAttributes(item).colorTemperatureRange;
-              let percent = Number(members[member].state);
+              let percent = parseFloat(members[member].state);
               if (this.getColorTemperatureInverted(item)) {
                 percent = 100 - percent;
               }

--- a/functions/devices/tv.js
+++ b/functions/devices/tv.js
@@ -112,7 +112,7 @@ class TV extends DefaultDevice {
           state.playbackState = members[member].state;
           break;
         case 'tvVolume':
-          state.currentVolume = Math.round(Number(members[member].state)) || 0;
+          state.currentVolume = Math.round(parseFloat(members[member].state)) || 0;
           break;
         case 'tvChannel':
           state.channelNumber = members[member].state;

--- a/tests/devices/charger.test.js
+++ b/tests/devices/charger.test.js
@@ -315,7 +315,7 @@ describe('Charger Device', () => {
           },
           {
             name: 'CapacityRemaining',
-            state: '4000.123',
+            state: '4000.123 wh',
             metadata: {
               ga: {
                 value: 'chargerCapacityRemaining'

--- a/tests/devices/climatesensor.test.js
+++ b/tests/devices/climatesensor.test.js
@@ -135,7 +135,7 @@ describe('ClimateSensor Device', () => {
         },
         {
           name: 'Humidity',
-          state: '59.7',
+          state: '59.7 %',
           type: 'Number',
           metadata: {
             ga: {
@@ -182,7 +182,7 @@ describe('ClimateSensor Device', () => {
       members: [
         {
           name: 'Humidity',
-          state: '30.3',
+          state: '30.3 %',
           type: 'Number',
           metadata: {
             ga: {

--- a/tests/devices/dimmablelight.test.js
+++ b/tests/devices/dimmablelight.test.js
@@ -21,7 +21,7 @@ describe('DimmableLight Device', () => {
   });
 
   test('getState', () => {
-    expect(Device.getState({ state: '50' })).toStrictEqual({
+    expect(Device.getState({ state: '50 %' })).toStrictEqual({
       on: true,
       brightness: 50
     });

--- a/tests/devices/fan.test.js
+++ b/tests/devices/fan.test.js
@@ -85,13 +85,13 @@ describe('Fan Device', () => {
   });
 
   test('getState', () => {
-    expect(Device.getState({ state: '50' })).toStrictEqual({
+    expect(Device.getState({ state: '50 %' })).toStrictEqual({
       currentFanSpeedPercent: 50,
       on: true
     });
     expect(
       Device.getState({
-        state: '50',
+        state: '50 upm',
         metadata: {
           ga: {
             config: {

--- a/tests/devices/humiditysensor.test.js
+++ b/tests/devices/humiditysensor.test.js
@@ -30,7 +30,7 @@ describe('HumiditySensor Device', () => {
   });
 
   test('getState', () => {
-    expect(Device.getState({ state: '10.3' })).toStrictEqual({
+    expect(Device.getState({ state: '9.6 %' })).toStrictEqual({
       humidityAmbientPercent: 10,
       humiditySetpointPercent: 10
     });

--- a/tests/devices/openclosedevice.test.js
+++ b/tests/devices/openclosedevice.test.js
@@ -84,7 +84,7 @@ describe('OpenCloseDevice Device', () => {
     test('getState Rollershutter', () => {
       const item = {
         type: 'Rollershutter',
-        state: '25'
+        state: '25 %'
       };
       expect(Device.getState(item)).toStrictEqual({
         openPercent: 75

--- a/tests/devices/sensor.test.js
+++ b/tests/devices/sensor.test.js
@@ -96,7 +96,7 @@ describe('Sensor Device', () => {
             }
           }
         },
-        state: '10'
+        state: '10 ppm'
       };
       expect(Device.getState(item)).toStrictEqual({
         currentSensorStateData: [
@@ -104,6 +104,29 @@ describe('Sensor Device', () => {
             currentSensorState: 'good',
             name: 'Sensor',
             rawValue: 10
+          }
+        ]
+      });
+    });
+
+    test('getState with string state', () => {
+      const item = {
+        metadata: {
+          ga: {
+            config: {
+              sensorName: 'Sensor',
+              valueUnit: 'AQI',
+              states: 'good=good,moderate=moderate,poor=poor'
+            }
+          }
+        },
+        state: 'moderate'
+      };
+      expect(Device.getState(item)).toStrictEqual({
+        currentSensorStateData: [
+          {
+            currentSensorState: 'moderate',
+            name: 'Sensor'
           }
         ]
       });

--- a/tests/devices/speaker.test.js
+++ b/tests/devices/speaker.test.js
@@ -57,7 +57,7 @@ describe('Speaker Device', () => {
   });
 
   test('getState', () => {
-    expect(Device.getState({ state: '10' })).toStrictEqual({
+    expect(Device.getState({ state: '10 %' })).toStrictEqual({
       currentVolume: 10
     });
     expect(Device.getState({ state: '90' })).toStrictEqual({

--- a/tests/devices/specialcolorlight.test.js
+++ b/tests/devices/specialcolorlight.test.js
@@ -425,7 +425,7 @@ describe('SpecialColorLight Device', () => {
         },
         members: [
           {
-            state: '0',
+            state: '0 %',
             metadata: {
               ga: {
                 value: 'lightBrightness'
@@ -433,7 +433,7 @@ describe('SpecialColorLight Device', () => {
             }
           },
           {
-            state: '80',
+            state: '80 K',
             metadata: {
               ga: {
                 value: 'lightColorTemperature'

--- a/tests/devices/tv.test.js
+++ b/tests/devices/tv.test.js
@@ -500,7 +500,7 @@ describe('TV Device', () => {
             }
           },
           {
-            state: '50',
+            state: '50 %',
             metadata: {
               ga: {
                 value: 'tvVolume'


### PR DESCRIPTION
Item.state returns number+unit for items with units of measurement, e.g. "10.5 %", "22 °C". When using units, humidity should be represented by a Number:Dimensionless item with a "%" unit set in its metadata[1]. For those: Number("10.5 %") is NaN, but parseFloat("10.5 %") returns 10.5.

[1] See https://www.openhab.org/docs/concepts/units-of-measurement.html#list-of-units