### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
         "jest": "^30.4.2",
-        "nock": "^14.0.15",
-        "prettier": "3.8.4"
+        "nock": "^14.0.16",
+        "prettier": "3.8.5"
       },
       "engines": {
         "node": ">=22"
@@ -4557,9 +4557,9 @@
       }
     },
     "node_modules/nock": {
-      "version": "14.0.15",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.15.tgz",
-      "integrity": "sha512-S0a47C9pLvcYx/Ugf0H30BVBEcUgMMBDk9VJIDlJ8XGrfH2QDUD4Tgdp45qDIiHttokBG+IbsOtsvIjGR/j3bg==",
+      "version": "14.0.16",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.16.tgz",
+      "integrity": "sha512-8r4KEc6nT1D/fdLD/R1BO1CPaVEL8o40u/guFRJlXabN7vr3RmMqyjsY5Krt0nMwhsOAwXQ/mtN5vy5Jh3aErg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4878,9 +4878,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.5.tgz",
+      "integrity": "sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "contributors": [
     "Michael Krug"
   ],
-  "packageManager": "npm@11.12.1",
+  "packageManager": "npm@11.17.0",
   "scripts": {
     "start": "node testServer.js",
     "test": "jest --silent --coverage",
@@ -45,7 +45,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
     "jest": "^30.4.2",
-    "nock": "^14.0.15",
-    "prettier": "3.8.4"
+    "nock": "^14.0.16",
+    "prettier": "3.8.5"
   }
 }


### PR DESCRIPTION
This pull request updates the project's dependencies to keep them current and secure. The most significant changes are version bumps for the package manager and two development dependencies.

Dependency updates:

* Updated `npm` version in the `packageManager` field from `11.12.1` to `11.17.0` in `package.json`.
* Updated `nock` development dependency from `^14.0.15` to `^14.0.16` in `package.json`.
* Updated `prettier` development dependency from `3.8.4` to `3.8.5` in `package.json`.